### PR TITLE
Possible fix for empty array values

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -123,6 +123,9 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart,
 				return ConversionError{path, key}
 			}
 		}
+		if len(items) == 1 && items[0].Kind() == reflect.Invalid {
+			items[0] = reflect.Zero(elemT)
+		}
 		value := reflect.Append(reflect.MakeSlice(t, 0, 0), items...)
 		v.Set(value)
 	} else {


### PR DESCRIPTION
Gorilla/Schema crashes when the items array in lines 98-127 in decoder.go contains reflect.Invalid elements.  This is caused by array elements that are empty.  I don't know if it crashes if the array is greater than one, so I hacked it to only do something if the array size is 1.
