### PR TITLE
Updated doc.go to include an example of schema w/ r.PostForm()

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -24,7 +24,25 @@ The basic usage is really simple. Given this struct:
 
 This is just a simple example and it doesn't make a lot of sense to create
 the map manually. Typically it will come from a http.Request object and
-will be of type url.Values: http.Request.Form or http.Request.MultipartForm.
+will be of type url.Values: http.Request.Form or http.Request.MultipartForm:
+
+	func MyHandler(w http.ResponseWriter, r *http.Request) {
+		err := r.ParseForm()
+
+		if err != nil {
+			// Handle error
+		}
+
+		decoder := schema.NewDecoder()
+		// r.PostForm is a map of our POST form values
+		err := decoder.Decode(person, r.PostForm)
+
+		if err != nil {
+			// Handle error
+		}
+
+		// Do something with person.Name or person.Phone
+	}
 
 Note: it is a good idea to set a Decoder instance as a package global,
 because it caches meta-data about structs, and a instance can be shared safely:


### PR DESCRIPTION
I've added a simple (but explicit) example of decoding `r.PostForm()` values into a struct using schema. The docs currently allude to this, but I feel it may be a little more "newbie friendly" if we spell out a common use-case.
