### PR TITLE
Change cache mutex to sync.RWMutex

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -28,7 +28,7 @@ func newCache() *cache {
 
 // cache caches meta-data about a struct.
 type cache struct {
-	l    sync.Mutex
+	l    sync.RWMutex
 	m    map[reflect.Type]*structInfo
 	conv map[reflect.Type]Converter
 }
@@ -102,9 +102,9 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 
 // get returns a cached structInfo, creating it if necessary.
 func (c *cache) get(t reflect.Type) *structInfo {
-	c.l.Lock()
+	c.l.RLock()
 	info := c.m[t]
-	c.l.Unlock()
+	c.l.RUnlock()
 	if info == nil {
 		info = c.create(t)
 		c.l.Lock()


### PR DESCRIPTION
A small tweak to the cache mutex that could help performance. Multiple reads to the cache don't need to exclude each other. Let the lock be held by an arbitrary number of readers or a single writer. Now once the cache is fully primed, there won't be any blocking.
