### PR TITLE
Support multiple-level embedded structs

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -108,7 +108,7 @@ func (c *cache) get(t reflect.Type) *structInfo {
 	info := c.m[t]
 	c.l.RUnlock()
 	if info == nil {
-		info = c.create(t)
+		info = c.create(t, nil)
 		c.l.Lock()
 		c.m[t] = info
 		c.l.Unlock()
@@ -117,8 +117,10 @@ func (c *cache) get(t reflect.Type) *structInfo {
 }
 
 // creat creates a structInfo with meta-data about a struct.
-func (c *cache) create(t reflect.Type) *structInfo {
-	info := &structInfo{fields: make(map[string]*fieldInfo)}
+func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
+	if info == nil {
+		info = &structInfo{fields: make(map[string]*fieldInfo)}
+	}
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		if field.Anonymous {
@@ -127,9 +129,7 @@ func (c *cache) create(t reflect.Type) *structInfo {
 				ft = ft.Elem()
 			}
 			if ft.Kind() == reflect.Struct {
-				for j := 0; j < ft.NumField(); j++ {
-					c.createField(ft.Field(j), info)
-				}
+				c.create(ft, info)
 			}
 		}
 		c.createField(field, info)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -685,6 +685,21 @@ func TestEmbeddedField(t *testing.T) {
 	}
 }
 
+type S11 struct {
+	S10
+}
+
+func TestMultipleLevelEmbeddedField(t *testing.T) {
+	data := map[string][]string{
+		"Id": {"identifier"},
+	}
+	s := &S11{}
+	err := NewDecoder().Decode(s, data)
+	if s.Id != "identifier" {
+		t.Errorf("Missing support for multiple-level embedded fields (%v)", err)
+	}
+}
+
 func TestInvalidPath(t *testing.T) {
 	data := map[string][]string{
 		"Foo.Bar": {"baz"},


### PR DESCRIPTION
Currently, this library doesn't support decoding into a struct with multiple-level embedded structs. See TestMultipleLevelEmbeddedField in this PR for an example:

``` go
type S9 struct {
    Id string
}

type S10 struct {
    S9
}

type S11 struct {
    S10
}

func TestMultipleLevelEmbeddedField(t *testing.T) {
    data := map[string][]string{
        "Id": {"identifier"},
    }
    s := &S11{}
    err := NewDecoder().Decode(s, data)
    if s.Id != "identifier" {
        t.Errorf("Missing support for multiple-level embedded fields (%v)", err)
    }
}
```

Without the other changes in this PR, that test case fails with the following message:

```
--- FAIL: TestMultipleLevelEmbeddedField-8 (0.00 seconds)
    decoder_test.go:699: Missing support for multiple-level embedded fields (schema: invalid path "Id")
```

This PR adds support for multiple-level embedded fields. All tests pass.
