### PR TITLE
Fix empty param slice panic

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -164,8 +164,11 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart,
 		value := reflect.Append(reflect.MakeSlice(t, 0, 0), items...)
 		v.Set(value)
 	} else {
-		// Use the last value provided
-		val := values[len(values)-1]
+		val := ""
+		// Use the last value provided if any values were provided
+		if len(values) > 0 {
+			val = values[len(values)-1]
+		}
 
 		if val == "" {
 			if d.zeroEmpty {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -24,6 +24,7 @@ type S1 struct {
 	F11 []*S1   `schema:"f11"`
 	F12 *[]S1   `schema:"f12"`
 	F13 *[]*S1  `schema:"f13"`
+	F14 int     `schema:"f14"`
 }
 
 type S2 struct {
@@ -49,6 +50,7 @@ func TestAll(t *testing.T) {
 		"f12.0.f12.1.f6": {"123", "124"},
 		"f13.0.f13.0.f6": {"131", "132"},
 		"f13.0.f13.1.f6": {"133", "134"},
+		"f14":            {},
 	}
 	f2 := 2
 	f41, f42 := 41, 42
@@ -109,6 +111,7 @@ func TestAll(t *testing.T) {
 				},
 			},
 		},
+		F14: 0,
 	}
 
 	s := &S1{}
@@ -286,6 +289,9 @@ func TestAll(t *testing.T) {
 				}
 			}
 		}
+	}
+	if s.F14 != e.F14 {
+		t.Errorf("f14: expected %v, got %v", e.F14, s.F14)
 	}
 }
 


### PR DESCRIPTION
URL parameters can have no values (eg foo=&bar=blah), and Go net/url will produce a url.Values with an empty slice. Schema decode panics as it assumes there will always be at least one value for a parameter appearing in the map. Make it support empty slices properly.
