### PR TITLE
Support multiple aliases for a given field.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -139,8 +139,8 @@ func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
 
 // createField creates a fieldInfo for the given field.
 func (c *cache) createField(field reflect.StructField, info *structInfo) {
-	alias := fieldAlias(field, c.tag)
-	if alias == "-" {
+	aliases := fieldAliases(field, c.tag)
+	if aliases[0] == "-" {
 		// Ignore this field.
 		return
 	}
@@ -164,12 +164,14 @@ func (c *cache) createField(field reflect.StructField, info *structInfo) {
 		}
 	}
 
-	info.fields = append(info.fields, &fieldInfo{
-		typ:   field.Type,
-		name:  field.Name,
-		ss:    isSlice && isStruct,
-		alias: alias,
-	})
+	for _, alias := range aliases {
+		info.fields = append(info.fields, &fieldInfo{
+			typ:   field.Type,
+			name:  field.Name,
+			ss:    isSlice && isStruct,
+			alias: alias,
+		})
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -203,7 +205,7 @@ type pathPart struct {
 // ----------------------------------------------------------------------------
 
 // fieldAlias parses a field tag to get a field alias.
-func fieldAlias(field reflect.StructField, tagName string) string {
+func fieldAliases(field reflect.StructField, tagName string) []string {
 	var alias string
 	if tag := field.Tag.Get(tagName); tag != "" {
 		// For now tags only support the name but let's folow the
@@ -217,5 +219,5 @@ func fieldAlias(field reflect.StructField, tagName string) string {
 	if alias == "" {
 		alias = field.Name
 	}
-	return alias
+	return strings.Split(alias, "|")
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -25,6 +25,8 @@ type S1 struct {
 	F12 *[]S1   `schema:"f12"`
 	F13 *[]*S1  `schema:"f13"`
 	F14 int     `schema:"f14"`
+	F15 int     `schema:"f15|f15b"`
+	F16 int     `schema:"f16|f16b"`
 }
 
 type S2 struct {
@@ -51,6 +53,8 @@ func TestAll(t *testing.T) {
 		"f13.0.f13.0.f6": {"131", "132"},
 		"f13.0.f13.1.f6": {"133", "134"},
 		"f14":            {},
+		"f15b":           {"151"},
+		"f16":            {"161"},
 	}
 	f2 := 2
 	f41, f42 := 41, 42
@@ -112,6 +116,8 @@ func TestAll(t *testing.T) {
 			},
 		},
 		F14: 0,
+		F15: 151,
+		F16: 161,
 	}
 
 	s := &S1{}
@@ -293,6 +299,12 @@ func TestAll(t *testing.T) {
 	if s.F14 != e.F14 {
 		t.Errorf("f14: expected %v, got %v", e.F14, s.F14)
 	}
+	if s.F15 != e.F15 {
+		t.Errorf("f15: expected %v, got %v", e.F15, s.F15)
+	}
+	if s.F16 != e.F16 {
+		t.Errorf("f16: expected %v, got %v", e.F16, s.F16)
+	}
 }
 
 func BenchmarkAll(b *testing.B) {
@@ -314,6 +326,9 @@ func BenchmarkAll(b *testing.B) {
 		"f12.0.f12.1.f6": {"123", "124"},
 		"f13.0.f13.0.f6": {"131", "132"},
 		"f13.0.f13.1.f6": {"133", "134"},
+		"f14":            {},
+		"f15b":           {"151"},
+		"f16":            {"161"},
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
This is an idea we've kicked around. We have an API that unfortunately has multiple input parameters that map to the same field. Currently we handle this aliasing first, then decode via schema, but it'd be a lot easier if it was handled automatically by schema. I'm not super tied to how I implemented this, just would like the concept. 
