### PR TITLE
resolve issue #33

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -50,6 +50,9 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 	path := make([]string, 0)
 	keys := strings.Split(p, ".")
 	for i := 0; i < len(keys); i++ {
+		if t.Kind() != reflect.Struct {
+			return nil, invalidPath
+		}
 		if struc = c.get(t); struc == nil {
 			return nil, invalidPath
 		}
@@ -87,10 +90,10 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 					t = t.Elem()
 				}
 			}
-		} else if field.typ.Kind() == reflect.Struct {
-			t = field.typ
-		} else if field.typ.Kind() == reflect.Ptr && field.typ.Elem().Kind() == reflect.Struct {
+		} else if field.typ.Kind() == reflect.Ptr {
 			t = field.typ.Elem()
+		} else {
+			t = field.typ
 		}
 	}
 	// Add the remaining.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -5,7 +5,7 @@
 package schema
 
 import (
-	//"reflect"
+	"reflect"
 	"testing"
 )
 
@@ -1075,5 +1075,41 @@ func TestCSVStringSlice(t *testing.T) {
 	}
 	if s.ID[0] != "0,1" {
 		t.Errorf("Expected []{0, 1} got %+v", s)
+	}
+}
+
+//Invalid data provided by client should not panic (github issue 33)
+func TestInvalidDataProvidedByClient(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panicked calling decoder.Decode: %v", r)
+		}
+	}()
+
+	type S struct {
+		f string
+	}
+
+	data := map[string][]string{
+		"f.f": {"v"},
+	}
+
+	err := NewDecoder().Decode(new(S), data)
+	if err == nil {
+		t.Errorf("invalid path in decoder.Decode should return an error.")
+	}
+}
+
+// underlying cause of error in issue 33
+func TestInvalidPathInCacheParsePath(t *testing.T) {
+	type S struct {
+		f string
+	}
+
+	typ := reflect.ValueOf(new(S)).Elem().Type()
+	c := newCache()
+	_, err := c.parsePath("f.f", typ)
+	if err == nil {
+		t.Errorf("invalid path in cache.parsePath should return an error.")
 	}
 }


### PR DESCRIPTION
add a test case for issue #33 and a test case for the cause of issue #33
modify parsePath to descend non-struct fields to check for invalid duplicate path keys