### PR TITLE
resolve issue #37

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -55,7 +55,7 @@ func (d *Decoder) IgnoreUnknownKeys(i bool) {
 
 // RegisterConverter registers a converter function for a custom type.
 func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) {
-	d.cache.conv[reflect.TypeOf(value).Kind()] = converterFunc
+	d.cache.regconv[reflect.TypeOf(value)] = converterFunc
 }
 
 // Decode decodes a map[string][]string to a struct.
@@ -140,7 +140,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart,
 		if isPtrElem {
 			elemT = elemT.Elem()
 		}
-		conv := d.cache.conv[elemT.Kind()]
+		conv := d.cache.converter(elemT)
 		if conv == nil {
 			return fmt.Errorf("schema: converter not found for %v", elemT)
 		}
@@ -193,7 +193,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart,
 			if d.zeroEmpty {
 				v.Set(reflect.Zero(t))
 			}
-		} else if conv := d.cache.conv[t.Kind()]; conv != nil {
+		} else if conv := d.cache.converter(t); conv != nil {
 			if value := conv(val); value.IsValid() {
 				v.Set(value.Convert(t))
 			} else {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1124,3 +1124,27 @@ func TestDecodeToTypedField(t *testing.T) {
 		t.Errorf("s1: expected %v, got %v", true, s1.Aa)
 	}
 }
+
+// issue 37
+func TestRegisterConverter(t *testing.T) {
+	type Aa int
+	type Bb int
+	s1 := &struct {
+		Aa
+		Bb
+	}{}
+	decoder := NewDecoder()
+
+	decoder.RegisterConverter(s1.Aa, func(s string) reflect.Value { return reflect.ValueOf(1) })
+	decoder.RegisterConverter(s1.Bb, func(s string) reflect.Value { return reflect.ValueOf(2) })
+
+	v1 := map[string][]string{"Aa": {"4"}, "Bb": {"5"}}
+	decoder.Decode(s1, v1)
+
+	if s1.Aa != Aa(1) {
+		t.Errorf("s1.Aa: expected %v, got %v", 1, s1.Aa)
+	}
+	if s1.Bb != Bb(2) {
+		t.Errorf("s1.Bb: expected %v, got %v", 2, s1.Bb)
+	}
+}


### PR DESCRIPTION
add unit test for issue #37

store registered converters in cache.regconv, a map keyed on reflect.Type
when looking for a converter, if one isn't found in cache.regconv, look for one
 in cache.conv, keyed on reflect.Kind
