### PR TITLE
Add Encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ schema
 ======
 [![GoDoc](https://godoc.org/github.com/gorilla/schema?status.svg)](https://godoc.org/github.com/gorilla/schema) [![Build Status](https://travis-ci.org/gorilla/schema.png?branch=master)](https://travis-ci.org/gorilla/schema)
 
-Package gorilla/schema fills a struct with form values.
+Package gorilla/schema converts structs to and from form values.
 
 ## Example
 
@@ -36,6 +36,28 @@ func MyHandler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+Conversely, contents of a struct can be encoded into form values. Here's a variant of the previous example using the Encoder:
+
+```go
+var encoder = schema.NewEncoder()
+
+func MyHttpRequest() {
+    person := Person{"Jane Doe", "555-5555"}
+    form := url.Values{}
+
+    err := encoder.Encode(person, form)
+
+    if err != nil {
+        // Handle error
+    }
+
+    // Use form values, for example, with an http client
+    client := new(http.Client)
+    res, err := client.PostForm("http://my-api.test", form)
+}
+
+```
+
 To define custom names for fields, use a struct tag "schema". To not populate certain fields, use a dash for the name and it will be ignored:
 
 ```go
@@ -46,7 +68,7 @@ type Person struct {
 }
 ```
 
-The supported field types in the destination struct are:
+The supported field types in the struct are:
 
 * bool
 * float variants (float32, float64)

--- a/encoder.go
+++ b/encoder.go
@@ -1,0 +1,133 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+type encoderFunc func(reflect.Value) string
+
+// Encoder encodes values from a struct into url.Values.
+type Encoder struct {
+	cache  *cache
+	regenc map[reflect.Type]encoderFunc
+}
+
+// NewEncoder returns a new Encoder with defaults.
+func NewEncoder() *Encoder {
+	return &Encoder{cache: newCache(), regenc: make(map[reflect.Type]encoderFunc)}
+}
+
+// Encode encodes a struct into map[string][]string.
+//
+// Intended for use with url.Values.
+func (e *Encoder) Encode(src interface{}, dst map[string][]string) error {
+	v := reflect.ValueOf(src)
+
+	return e.encode(v, dst)
+}
+
+// RegisterEncoder registers a converter for encoding a custom type.
+func (e *Encoder) RegisterEncoder(value interface{}, encoder func(reflect.Value) string) {
+	e.regenc[reflect.TypeOf(value)] = encoder
+}
+
+func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return errors.New("schema: interface must be a struct")
+	}
+	t := v.Type()
+
+	errors := MultiError{}
+
+	for i := 0; i < v.NumField(); i++ {
+		name, opts := fieldAlias(t.Field(i), e.cache.tag)
+		if name == "-" {
+			continue
+		}
+
+		encFunc := typeEncoder(v.Field(i).Type(), e.regenc)
+		if v.Field(i).Type().Kind() == reflect.Struct {
+			e.encode(v.Field(i), dst)
+			continue
+		}
+
+		if encFunc == nil {
+			errors[v.Field(i).Type().String()] = fmt.Errorf("schema: encoder not found for %v", v.Field(i))
+			continue
+		}
+
+		value := encFunc(v.Field(i))
+		if value == "" && opts.Contains("omitempty") {
+			continue
+		}
+
+		dst[name] = []string{value}
+	}
+
+	return errors
+}
+
+func typeEncoder(t reflect.Type, reg map[reflect.Type]encoderFunc) encoderFunc {
+	if f, ok := reg[t]; ok {
+		return f
+	}
+
+	switch t.Kind() {
+	case reflect.Bool:
+		return encodeBool
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return encodeInt
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return encodeUint
+	case reflect.Float32:
+		return encodeFloat32
+	case reflect.Float64:
+		return encodeFloat64
+	case reflect.Ptr:
+		f := typeEncoder(t.Elem(), reg)
+		return func(v reflect.Value) string {
+			if v.IsNil() {
+				return "null"
+			}
+			return f(v.Elem())
+		}
+	case reflect.String:
+		return encodeString
+	default:
+		return nil
+	}
+}
+
+func encodeBool(v reflect.Value) string {
+	return strconv.FormatBool(v.Bool())
+}
+
+func encodeInt(v reflect.Value) string {
+	return strconv.FormatInt(int64(v.Int()), 10)
+}
+
+func encodeUint(v reflect.Value) string {
+	return strconv.FormatUint(uint64(v.Uint()), 10)
+}
+
+func encodeFloat(v reflect.Value, bits int) string {
+	return strconv.FormatFloat(v.Float(), 'f', 6, bits)
+}
+
+func encodeFloat32(v reflect.Value) string {
+	return encodeFloat(v, 32)
+}
+
+func encodeFloat64(v reflect.Value) string {
+	return encodeFloat(v, 64)
+}
+
+func encodeString(v reflect.Value) string {
+	return v.String()
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,173 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+)
+
+type E1 struct {
+	F01 int     `schema:"f01"`
+	F02 int     `schema:"-"`
+	F03 string  `schema:"f03"`
+	F04 string  `schema:"f04,omitempty"`
+	F05 bool    `schema:"f05"`
+	F06 bool    `schema:"f06"`
+	F07 *string `schema:"f07"`
+	F08 *int8   `schema:"f08"`
+	F09 float64 `schema:"f09"`
+	F10 func()  `schema:"f10"`
+	F11 inner
+}
+type inner struct {
+	F12 int
+}
+
+func TestFilled(t *testing.T) {
+	f07 := "seven"
+	var f08 int8 = 8
+	s := &E1{
+		F01: 1,
+		F02: 2,
+		F03: "three",
+		F04: "four",
+		F05: true,
+		F06: false,
+		F07: &f07,
+		F08: &f08,
+		F09: 1.618,
+		F10: func() {},
+		F11: inner{12},
+	}
+
+	vals := make(map[string][]string)
+	errs := NewEncoder().Encode(s, vals)
+
+	valExists(t, "f01", "1", vals)
+	valNotExists(t, "f02", vals)
+	valExists(t, "f03", "three", vals)
+	valExists(t, "f05", "true", vals)
+	valExists(t, "f06", "false", vals)
+	valExists(t, "f07", "seven", vals)
+	valExists(t, "f08", "8", vals)
+	valExists(t, "f09", "1.618000", vals)
+	valExists(t, "F12", "12", vals)
+
+	emptyErr := MultiError{}
+	if errs.Error() == emptyErr.Error() {
+		t.Errorf("Expected error got %v", errs)
+	}
+}
+
+type Aa int
+
+type E3 struct {
+	F01 bool    `schema:"f01"`
+	F02 float32 `schema:"f02"`
+	F03 float64 `schema:"f03"`
+	F04 int     `schema:"f04"`
+	F05 int8    `schema:"f05"`
+	F06 int16   `schema:"f06"`
+	F07 int32   `schema:"f07"`
+	F08 int64   `schema:"f08"`
+	F09 string  `schema:"f09"`
+	F10 uint    `schema:"f10"`
+	F11 uint8   `schema:"f11"`
+	F12 uint16  `schema:"f12"`
+	F13 uint32  `schema:"f13"`
+	F14 uint64  `schema:"f14"`
+	F15 Aa      `schema:"f15"`
+}
+
+// Test compatibility with default decoder types.
+func TestCompat(t *testing.T) {
+	src := &E3{
+		F01: true,
+		F02: 4.2,
+		F03: 4.3,
+		F04: -42,
+		F05: -43,
+		F06: -44,
+		F07: -45,
+		F08: -46,
+		F09: "foo",
+		F10: 42,
+		F11: 43,
+		F12: 44,
+		F13: 45,
+		F14: 46,
+		F15: 1,
+	}
+	dst := &E3{}
+
+	vals := make(map[string][]string)
+	encoder := NewEncoder()
+	decoder := NewDecoder()
+
+	encoder.RegisterEncoder(src.F15, func(reflect.Value) string { return "1" })
+	decoder.RegisterConverter(src.F15, func(string) reflect.Value { return reflect.ValueOf(1) })
+
+	encoder.Encode(src, vals)
+	decoder.Decode(dst, vals)
+
+	if *src != *dst {
+		t.Errorf("Decoder-Encoder compatibility: expected %v, got %v\n", src, dst)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	s := &E1{
+		F01: 1,
+		F02: 2,
+		F03: "three",
+	}
+
+	vals := make(map[string][]string)
+	_ = NewEncoder().Encode(s, vals)
+
+	valExists(t, "f03", "three", vals)
+	valNotExists(t, "f04", vals)
+}
+
+func TestStruct(t *testing.T) {
+	estr := "schema: interface must be a struct"
+	vals := make(map[string][]string)
+	err := NewEncoder().Encode("hello world", vals)
+
+	if err.Error() != estr {
+		t.Errorf("Expected: %s, got %v", estr, err)
+	}
+}
+
+func TestRegisterEncoder(t *testing.T) {
+	type oneAsWord int
+	type twoAsWord int
+
+	s1 := &struct {
+		oneAsWord
+		twoAsWord
+	}{1, 2}
+	v1 := make(map[string][]string)
+
+	encoder := NewEncoder()
+	encoder.RegisterEncoder(s1.oneAsWord, func(v reflect.Value) string { return "one" })
+	encoder.RegisterEncoder(s1.twoAsWord, func(v reflect.Value) string { return "two" })
+
+	encoder.Encode(s1, v1)
+
+	valExists(t, "oneAsWord", "one", v1)
+	valExists(t, "twoAsWord", "two", v1)
+}
+
+func valExists(t *testing.T, key string, expect string, result map[string][]string) {
+	if val, ok := result[key]; !ok {
+		t.Error("Key not found. Expected: " + expect)
+	} else if val[0] != expect {
+		t.Error("Unexpected value. Expected: " + expect + "; got: " + val[0] + ".")
+	}
+}
+
+func valNotExists(t *testing.T, key string, result map[string][]string) {
+	if val, ok := result[key]; ok {
+		t.Error("Key not ommited. Expected: empty; got: " + val[0] + ".")
+	}
+}


### PR DESCRIPTION
Getting the ball rolling on this.

As for custom converters, I have coded up a [separate branch](https://github.com/kladd/schema/tree/encoder-with-cache) that uses the existing cache to achieve this. It has the added benefit of unifying the way conversion functions are selected between the decoder and encoder. However, it changes the signature of Converter. Calling for opinions.

Resolves #44 
