### PR TITLE
Map underscore-style form fields to CamelCase struct fields

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -19,10 +19,11 @@ func NewDecoder() *Decoder {
 
 // Decoder decodes values from a map[string][]string to a struct.
 type Decoder struct {
-	cache             *cache
-	zeroEmpty         bool
-	ignoreUnknownKeys bool
+	cache                 *cache
+	zeroEmpty             bool
+	ignoreUnknownKeys     bool
 }
+
 
 // SetAliasTag changes the tag used to locate custom field aliases.
 // The default tag is "schema".
@@ -52,6 +53,15 @@ func (d *Decoder) ZeroEmpty(z bool) {
 // To preserve backwards compatibility, the default value is false.
 func (d *Decoder) IgnoreUnknownKeys(i bool) {
 	d.ignoreUnknownKeys = i
+}
+
+// UnderscoreToCamelCase allows automatically map form values named
+// in "underscore" style to struct fields with "CamelCase" naming
+// convention.
+//
+// The default value is false.
+func (d *Decoder) UnderscoreToCamelCase(u bool) {
+	d.cache.underscoreToCamelCase = u
 }
 
 // RegisterConverter registers a converter function for a custom type.


### PR DESCRIPTION
I am porting a large application (JSON API) from Perl to Go now. All protocol's fields are in "underscore" notation but in the server-side code I use structs with "CamelCase" notation. It is very annoying to write aliases for each field, that's why I've made a small patch whitch adds a new decoder's option named "UnderscoreToCamelCase". When checked, it automatically makes underscore-style aliases for CamelCase fields with empty tag.
P.S. Sorry for my English, it is not my native language.