### PR TITLE
Support custom converter from struct field names to form fields (callback)

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -11,6 +11,10 @@ import (
 
 type Converter func(string) reflect.Value
 
+// Custom converter for struct field names to form fields. It will be called if alias is empty. Converter func gets
+// name of the struct field and returns name of the corresponding form field.
+type NameConverter func(string) string
+
 var (
 	invalidValue = reflect.Value{}
 	boolType     = reflect.Bool

--- a/decoder.go
+++ b/decoder.go
@@ -59,6 +59,11 @@ func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) 
 	d.cache.regconv[reflect.TypeOf(value)] = converterFunc
 }
 
+// RegisterNameConverter registers custom converter from struct field names to form fields.
+func (d *Decoder) RegisterNameConverter(converterFunc NameConverter) {
+	d.cache.nameConverter = converterFunc
+}
+
 // Decode decodes a map[string][]string to a struct.
 //
 // The first parameter must be a pointer to a struct.


### PR DESCRIPTION
As discussed in https://github.com/gorilla/schema/pull/54 I have realized custom name converter. One difference from discussion: converter is a callback, not interface, because interface is excess in this case.
