### PR TITLE
Fix anonymous struct required check

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -139,6 +139,7 @@ func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
 			}
 			if ft.Kind() == reflect.Struct {
 				c.create(ft, info)
+				continue
 			}
 		}
 		c.createField(field, info)

--- a/cache.go
+++ b/cache.go
@@ -141,6 +141,7 @@ func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
 				bef := len(info.fields)
 				c.create(ft, info)
 				for _, fi := range info.fields[bef:len(info.fields)] {
+					// exclude required check because duplicated to embedded field
 					fi.required = false
 				}
 			}

--- a/cache.go
+++ b/cache.go
@@ -138,8 +138,11 @@ func (c *cache) create(t reflect.Type, info *structInfo) *structInfo {
 				ft = ft.Elem()
 			}
 			if ft.Kind() == reflect.Struct {
+				bef := len(info.fields)
 				c.create(ft, info)
-				continue
+				for _, fi := range info.fields[bef:len(info.fields)] {
+					fi.required = false
+				}
 			}
 		}
 		c.createField(field, info)
@@ -185,6 +188,7 @@ func (c *cache) createField(field reflect.StructField, info *structInfo) {
 		name:     field.Name,
 		ss:       isSlice && isStruct,
 		alias:    alias,
+		anon:     field.Anonymous,
 		required: options.Contains("required"),
 	})
 }
@@ -218,6 +222,7 @@ type fieldInfo struct {
 	name     string // field name in the struct.
 	ss       bool   // true if this is a slice of structs.
 	alias    string
+	anon     bool // is an embedded field
 	required bool // tag option
 }
 

--- a/decoder.go
+++ b/decoder.go
@@ -109,6 +109,7 @@ func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix 
 				if !f.anon {
 					return err
 				}
+				// check embedded parent field.
 				err2 := d.checkRequired(f.typ, src, prefix)
 				if err2 != nil {
 					return err

--- a/decoder.go
+++ b/decoder.go
@@ -106,7 +106,13 @@ func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix 
 		if f.typ.Kind() == reflect.Struct {
 			err := d.checkRequired(f.typ, src, prefix+f.alias+".")
 			if err != nil {
-				return err
+				if !f.anon {
+					return err
+				}
+				err2 := d.checkRequired(f.typ, src, prefix)
+				if err2 != nil {
+					return err
+				}
 			}
 		}
 		if f.required {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1461,30 +1461,90 @@ func TestRequiredField(t *testing.T) {
 
 type AS1 struct {
 	A int32 `schema:"a,required"`
+	E int32 `schema:"e,required"`
 }
 type AS2 struct {
 	AS1
 	B string `schema:"b,required"`
 }
+type AS3 struct {
+	C int32 `schema:"c"`
+}
+
+type AS4 struct {
+	AS3
+	D string `schema:"d"`
+}
 
 func TestAnonymousStructField(t *testing.T) {
-	var a AS2
-	v := map[string][]string{
-		"a": {"1"},
+	patterns := []map[string][]string{
+		{
+			"a": {"1"},
+			"e": {"2"},
+			"b": {"abc"},
+		},
+		{
+			"AS1.a": {"1"},
+			"AS1.e": {"2"},
+			"b":     {"abc"},
+		},
+	}
+	for _, v := range patterns {
+		a := AS2{}
+		err := NewDecoder().Decode(&a, v)
+		if err != nil {
+			t.Errorf("Decode failed %s, %#v", err, v)
+			continue
+		}
+		if a.A != 1 {
+			t.Errorf("A: expected %v, got %v", 1, a.A)
+		}
+		if a.E != 2 {
+			t.Errorf("E: expected %v, got %v", 2, a.E)
+		}
+		if a.B != "abc" {
+			t.Errorf("B: expected %v, got %v", "abc", a.B)
+		}
+		if a.AS1.A != 1 {
+			t.Errorf("AS1.A: expected %v, got %v", 1, a.AS1.A)
+		}
+		if a.AS1.E != 2 {
+			t.Errorf("AS1.E: expected %v, got %v", 2, a.AS1.E)
+		}
+	}
+	a := AS2{}
+	err := NewDecoder().Decode(&a, map[string][]string{
+		"e": {"2"},
 		"b": {"abc"},
+	})
+	if err == nil {
+		t.Errorf("error nil, a is empty expect")
 	}
-	err := NewDecoder().Decode(&a, v)
-	if err != nil {
-		t.Errorf("Decode failed %s", err)
-		return
+	patterns = []map[string][]string{
+		{
+			"c": {"1"},
+			"d": {"abc"},
+		},
+		{
+			"AS3.c": {"1"},
+			"d":     {"abc"},
+		},
 	}
-	if a.A != 1 {
-		t.Errorf("A: expected %v, got %v", 1, a.A)
-	}
-	if a.B != "abc" {
-		t.Errorf("B: expected %v, got %v", "abc", a.B)
-	}
-	if a.AS1.A != 1 {
-		t.Errorf("AS1.A: expected %v, got %v", 1, a.AS1.A)
+	for _, v := range patterns {
+		a := AS4{}
+		err := NewDecoder().Decode(&a, v)
+		if err != nil {
+			t.Errorf("Decode failed %s, %#v", err, v)
+			continue
+		}
+		if a.C != 1 {
+			t.Errorf("C: expected %v, got %v", 1, a.C)
+		}
+		if a.D != "abc" {
+			t.Errorf("D: expected %v, got %v", "abc", a.D)
+		}
+		if a.AS3.C != 1 {
+			t.Errorf("AS3.C: expected %v, got %v", 1, a.AS3.C)
+		}
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1458,3 +1458,33 @@ func TestRequiredField(t *testing.T) {
 		return
 	}
 }
+
+type AS1 struct {
+	A int32 `schema:"a,required"`
+}
+type AS2 struct {
+	AS1
+	B string `schema:"b,required"`
+}
+
+func TestAnonymousStructField(t *testing.T) {
+	var a AS2
+	v := map[string][]string{
+		"a": {"1"},
+		"b": {"abc"},
+	}
+	err := NewDecoder().Decode(&a, v)
+	if err != nil {
+		t.Errorf("Decode failed %s", err)
+		return
+	}
+	if a.A != 1 {
+		t.Errorf("A: expected %v, got %v", 1, a.A)
+	}
+	if a.B != "abc" {
+		t.Errorf("B: expected %v, got %v", "abc", a.B)
+	}
+	if a.AS1.A != 1 {
+		t.Errorf("AS1.A: expected %v, got %v", 1, a.AS1.A)
+	}
+}


### PR DESCRIPTION
I would like to use anonymous struct as a general purpose parameter.
But it does not work  when used with `required`.
Maybe `structInfo` has duplicate field.

for example:
```go
type WithVersion struct {
    Version string `schema:"version,required"`
}
type FooRequest struct {
    WithVersion
    FooId int64 `schema:"foo_id,required"`
}
type BarRequest struct {
    WithVersion
    BarId int64 `schema:"bar_id,required"`
}
```