### PR TITLE
Add SetAliasTag method for encoder

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -36,8 +36,8 @@ func (e *Encoder) RegisterEncoder(value interface{}, encoder func(reflect.Value)
 
 // SetAliasTag changes the tag used to locate custom field aliases.
 // The default tag is "schema".
-func (d *Encoder) SetAliasTag(tag string) {
-	d.cache.tag = tag
+func (e *Encoder) SetAliasTag(tag string) {
+	e.cache.tag = tag
 }
 
 func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {

--- a/encoder.go
+++ b/encoder.go
@@ -34,6 +34,12 @@ func (e *Encoder) RegisterEncoder(value interface{}, encoder func(reflect.Value)
 	e.regenc[reflect.TypeOf(value)] = encoder
 }
 
+// SetAliasTag changes the tag used to locate custom field aliases.
+// The default tag is "schema".
+func (d *Encoder) SetAliasTag(tag string) {
+	d.cache.tag = tag
+}
+
 func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -257,8 +257,7 @@ type E4 struct {
 }
 
 func TestEncoderSetAliasTag(t *testing.T) {
-	data := map[string][]string{
-	}
+	data := map[string][]string{}
 
 	s := E4{
 		ID: "foo",

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -251,3 +251,20 @@ func valNotExists(t *testing.T, key string, result map[string][]string) {
 		t.Error("Key not ommited. Expected: empty; got: " + val[0] + ".")
 	}
 }
+
+type E4 struct {
+	ID string `json:"id"`
+}
+
+func TestEncoderSetAliasTag(t *testing.T) {
+	data := map[string][]string{
+	}
+
+	s := E4{
+		ID: "foo",
+	}
+	encoder := NewEncoder()
+	encoder.SetAliasTag("json")
+	encoder.Encode(&s, data)
+	valExists(t, "id", "foo", data)
+}


### PR DESCRIPTION
Added a SetAliasTag method to the encoder.

Essentially I needed a symmetric api with the decoder so I can get values from an object and eventually put them back into the same object.  The decoder had a SetAliasTag method so it seemed intuitive to have it in the encoder as well.

Here is code that shows how this symmetry works:
```
package main

import "fmt"
import "github.com/melting/schema"

type person struct {
	Name       string `json:"name"`
	Age        int    `json:"age"`
	Occupation string `json:"job"`
}

func main() {
	src := &person{
		Name:       "Betty",
		Age:        46,
		Occupation: "CEO",
	}
	vals := map[string][]string{}
	dst := &person{}
	enc := schema.NewEncoder()
	dec := schema.NewDecoder()
	enc.SetAliasTag("json")
	dec.SetAliasTag("json")
	enc.Encode(src, vals)
	dec.Decode(dst, vals)
	if *src == *dst {
		fmt.Println("Symetry with aliased tags")
	} else {
		fmt.Println("FAIL")
	}
	fmt.Printf("src==dst=%s src=%s vals=%s dst=%s\n", *src == *dst, src, vals, dst)
}
```
