### PR TITLE
Encode returns nil for no errors

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -89,6 +89,10 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 		}
 	}
 
+	if len(errors) == 0 {
+		return nil
+	}
+
 	return errors
 }
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -42,6 +42,10 @@ func TestFilled(t *testing.T) {
 	vals := make(map[string][]string)
 	errs := NewEncoder().Encode(s, vals)
 
+	if errs == nil {
+		t.Error("Expected error got nil")
+	}
+
 	valExists(t, "f01", "1", vals)
 	valNotExists(t, "f02", vals)
 	valExists(t, "f03", "three", vals)
@@ -51,11 +55,6 @@ func TestFilled(t *testing.T) {
 	valExists(t, "f08", "8", vals)
 	valExists(t, "f09", "1.618000", vals)
 	valExists(t, "F12", "12", vals)
-
-	emptyErr := MultiError{}
-	if errs.Error() == emptyErr.Error() {
-		t.Errorf("Expected error got %v", errs)
-	}
 }
 
 type Aa int


### PR DESCRIPTION
Fixes issue #75 

`encode()` was returning a non-nil error when there were zero errors, breaking the Go convention of `if err != nil`