### PR TITLE
update configuration methods #93

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -26,8 +26,9 @@ type Decoder struct {
 
 // SetAliasTag changes the tag used to locate custom field aliases.
 // The default tag is "schema".
-func (d *Decoder) SetAliasTag(tag string) {
+func (d *Decoder) SetAliasTag(tag string) *Decoder {
 	d.cache.tag = tag
+	return d
 }
 
 // ZeroEmpty controls the behaviour when the decoder encounters empty values
@@ -38,8 +39,9 @@ func (d *Decoder) SetAliasTag(tag string) {
 //
 // The default value is false, that is empty values do not change
 // the value of the struct field.
-func (d *Decoder) ZeroEmpty(z bool) {
+func (d *Decoder) ZeroEmpty(z bool) *Decoder {
 	d.zeroEmpty = z
+	return d
 }
 
 // IgnoreUnknownKeys controls the behaviour when the decoder encounters unknown
@@ -50,13 +52,15 @@ func (d *Decoder) ZeroEmpty(z bool) {
 // will still be decoded in to the target struct.
 //
 // To preserve backwards compatibility, the default value is false.
-func (d *Decoder) IgnoreUnknownKeys(i bool) {
+func (d *Decoder) IgnoreUnknownKeys(i bool) *Decoder {
 	d.ignoreUnknownKeys = i
+	return d
 }
 
 // RegisterConverter registers a converter function for a custom type.
-func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) {
+func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) *Decoder {
 	d.cache.registerConverter(value, converterFunc)
+	return d
 }
 
 // Decode decodes a map[string][]string to a struct.

--- a/doc.go
+++ b/doc.go
@@ -49,6 +49,11 @@ because it caches meta-data about structs, and an instance can be shared safely:
 
 	var decoder = schema.NewDecoder()
 
+Almost all configuration methods return the underlying instance, so it's possible to
+method chain them in the declaration.
+
+	var decoder = schema.NewDecoder().SetAliasTag("mycustomtag").IgnoreUnknownKeys(false)
+
 To define custom names for fields, use a struct tag "schema". To not populate
 certain fields, use a dash for the name and it will be ignored:
 

--- a/encoder.go
+++ b/encoder.go
@@ -30,14 +30,16 @@ func (e *Encoder) Encode(src interface{}, dst map[string][]string) error {
 }
 
 // RegisterEncoder registers a converter for encoding a custom type.
-func (e *Encoder) RegisterEncoder(value interface{}, encoder func(reflect.Value) string) {
+func (e *Encoder) RegisterEncoder(value interface{}, encoder func(reflect.Value) string) *Encoder {
 	e.regenc[reflect.TypeOf(value)] = encoder
+	return e
 }
 
 // SetAliasTag changes the tag used to locate custom field aliases.
 // The default tag is "schema".
-func (e *Encoder) SetAliasTag(tag string) {
+func (e *Encoder) SetAliasTag(tag string) *Encoder {
 	e.cache.tag = tag
+	return e
 }
 
 func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {


### PR DESCRIPTION
This patch updates configuration methods on Encoder and Decoder.
In specific, the configuration methods now return a pointer to
the instance on which those methods were called. This facilities
method chaning in the instance declaration.