### PR TITLE
doc: fixed typo

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -121,7 +121,7 @@ field, we could not translate multiple values to it if we did not use an
 index for the parent struct.
 
 There's also the possibility to create a custom type that implements the
-TextUnmarshaler interface, and in this case there's no need to registry
+TextUnmarshaler interface, and in this case there's no need to register
 a converter, like:
 
 	type Person struct {


### PR DESCRIPTION
fixed typo in [doc.go:124](https://github.com/gorilla/schema/blob/e6c82218a8b3ed3cbeb5407429849c0b0b597d40/doc.go#L124), 'to registry' -> 'to register'