### PR TITLE
Fix slice of structs TextUnmarshaler.

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -106,7 +106,7 @@ func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix 
 		if f.typ.Kind() == reflect.Struct {
 			err := d.checkRequired(f.typ, src, prefix+f.alias+".")
 			if err != nil {
-				if !f.anon {
+				if !f.isAnonymous {
 					return err
 				}
 				// check embedded parent field.
@@ -116,7 +116,7 @@ func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix 
 				}
 			}
 		}
-		if f.required {
+		if f.isRequired {
 			key := f.alias
 			if prefix != "" {
 				key = prefix + key
@@ -185,7 +185,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 	// Get the converter early in case there is one for a slice type.
 	conv := d.cache.converter(t)
 	m := isTextUnmarshaler(v)
-	if conv == nil && t.Kind() == reflect.Slice && m.IsSlice {
+	if conv == nil && t.Kind() == reflect.Slice && m.IsSliceElement {
 		var items []reflect.Value
 		elemT := t.Elem()
 		isPtrElem := elemT.Kind() == reflect.Ptr
@@ -211,7 +211,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 				}
 			} else if m.IsValid {
 				u := reflect.New(elemT)
-				if m.IsPtr {
+				if m.IsSliceElementPtr {
 					u = reflect.New(reflect.PtrTo(elemT).Elem())
 				}
 				if err := u.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(value)); err != nil {
@@ -222,7 +222,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 						Err:   err,
 					}
 				}
-				if m.IsPtr {
+				if m.IsSliceElementPtr {
 					items = append(items, u.Elem().Addr())
 				} else if u.Kind() == reflect.Ptr {
 					items = append(items, u.Elem())
@@ -298,14 +298,27 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 				}
 			}
 		} else if m.IsValid {
-			// If the value implements the encoding.TextUnmarshaler interface
-			// apply UnmarshalText as the converter
-			if err := m.Unmarshaler.UnmarshalText([]byte(val)); err != nil {
-				return ConversionError{
-					Key:   path,
-					Type:  t,
-					Index: -1,
-					Err:   err,
+			if m.IsPtr {
+				u := reflect.New(v.Type())
+				if err := u.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(val)); err != nil {
+					return ConversionError{
+						Key:   path,
+						Type:  t,
+						Index: -1,
+						Err:   err,
+					}
+				}
+				v.Set(reflect.Indirect(u))
+			} else {
+				// If the value implements the encoding.TextUnmarshaler interface
+				// apply UnmarshalText as the converter
+				if err := m.Unmarshaler.UnmarshalText([]byte(val)); err != nil {
+					return ConversionError{
+						Key:   path,
+						Type:  t,
+						Index: -1,
+						Err:   err,
+					}
 				}
 			}
 		} else if conv := builtinConverters[t.Kind()]; conv != nil {
@@ -326,16 +339,16 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 }
 
 func isTextUnmarshaler(v reflect.Value) unmarshaler {
-
 	// Create a new unmarshaller instance
 	m := unmarshaler{}
-
-	// As the UnmarshalText function should be applied
-	// to the pointer of the type, we convert the value to pointer.
-	if v.CanAddr() {
-		v = v.Addr()
-	}
 	if m.Unmarshaler, m.IsValid = v.Interface().(encoding.TextUnmarshaler); m.IsValid {
+		return m
+	}
+	// As the UnmarshalText function should be applied to the pointer of the
+	// type, we check that type to see if it implements the necessary
+	// method.
+	if m.Unmarshaler, m.IsValid = reflect.New(v.Type()).Interface().(encoding.TextUnmarshaler); m.IsValid {
+		m.IsPtr = true
 		return m
 	}
 
@@ -345,12 +358,17 @@ func isTextUnmarshaler(v reflect.Value) unmarshaler {
 		t = t.Elem()
 	}
 	if t.Kind() == reflect.Slice {
-		// if t is a pointer slice, check if it implements encoding.TextUnmarshaler
-		m.IsSlice = true
+		// Check if the slice implements encoding.TextUnmarshaller
+		if m.Unmarshaler, m.IsValid = v.Interface().(encoding.TextUnmarshaler); m.IsValid {
+			return m
+		}
+		// If t is a pointer slice, check if its elements implement
+		// encoding.TextUnmarshaler
+		m.IsSliceElement = true
 		if t = t.Elem(); t.Kind() == reflect.Ptr {
 			t = reflect.PtrTo(t.Elem())
 			v = reflect.Zero(t)
-			m.IsPtr = true
+			m.IsSliceElementPtr = true
 			m.Unmarshaler, m.IsValid = v.Interface().(encoding.TextUnmarshaler)
 			return m
 		}
@@ -365,9 +383,18 @@ func isTextUnmarshaler(v reflect.Value) unmarshaler {
 // unmarshaller contains information about a TextUnmarshaler type
 type unmarshaler struct {
 	Unmarshaler encoding.TextUnmarshaler
-	IsSlice     bool
-	IsPtr       bool
-	IsValid     bool
+	// IsValid indicates whether the resolved type indicated by the other
+	// flags implements the encoding.TextUnmarshaler interface.
+	IsValid bool
+	// IsPtr indicates that the resolved type is the pointer of the original
+	// type.
+	IsPtr bool
+	// IsSliceElement indicates that the resolved type is a slice element of
+	// the original type.
+	IsSliceElement bool
+	// IsSliceElementPtr indicates that the resolved type is a pointer to a
+	// slice element of the original type.
+	IsSliceElementPtr bool
 }
 
 // Errors ---------------------------------------------------------------------

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1684,10 +1684,56 @@ func TestTextUnmarshalerTypeSlice(t *testing.T) {
 	}{}
 	decoder := NewDecoder()
 	if err := decoder.Decode(&s, data); err != nil {
-		t.Error("Error while decoding:", err)
+		t.Fatal("Error while decoding:", err)
 	}
 	expected := S20{"a", "b", "c"}
 	if !reflect.DeepEqual(expected, s.Value) {
 		t.Errorf("Expected %v errors, got %v", expected, s.Value)
+	}
+}
+
+type S21E struct{ ElementValue string }
+
+func (e *S21E) UnmarshalText(text []byte) error {
+	*e = S21E{"x"}
+	return nil
+}
+
+type S21 []S21E
+
+func (s *S21) UnmarshalText(text []byte) error {
+	*s = S21{{"a"}}
+	return nil
+}
+
+type S21B []S21E
+
+// Test to ensure that if custom type base on a slice of structs implements an
+// encoding.TextUnmarshaler interface it is unaffected by the special path
+// requirements imposed on a slice of structs.
+func TestTextUnmarshalerTypeSliceOfStructs(t *testing.T) {
+	data := map[string][]string{
+		"Value": []string{"raw a"},
+	}
+	// Implements encoding.TextUnmarshaler, should not throw invalid path
+	// error.
+	s := struct {
+		Value S21
+	}{}
+	decoder := NewDecoder()
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal("Error while decoding:", err)
+	}
+	expected := S21{{"a"}}
+	if !reflect.DeepEqual(expected, s.Value) {
+		t.Errorf("Expected %v errors, got %v", expected, s.Value)
+	}
+	// Does not implement encoding.TextUnmarshaler, should throw invalid
+	// path error.
+	sb := struct {
+		Value S21B
+	}{}
+	if err := decoder.Decode(&sb, data); err == invalidPath {
+		t.Fatal("Expecting invalid path error", err)
 	}
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -415,6 +415,5 @@ func TestRegisterEncoderCustomArrayType(t *testing.T) {
 		})
 
 		encoder.Encode(s, vals)
-		t.Log(vals)
 	}
 }


### PR DESCRIPTION
Fix handling of situation where a slice of structs implments the
encoding.TextUnmarshaler interface, previously it would return "invalid
path" error.

Includes, some minor refactoring and documentation to clarify
`isUnmarshaler` output.