### PR TITLE
Fix decoding of TextUnmarshaler to preserve existing values in a struct

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -295,7 +295,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 			}
 		} else if m.IsValid {
 			if m.IsPtr {
-				u := reflect.New(v.Type())
+				u := v.Addr()
 				if err := u.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(val)); err != nil {
 					return ConversionError{
 						Key:   path,

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1767,3 +1767,35 @@ func TestTextUnmarshalerEmpty(t *testing.T) {
 		t.Errorf("Expected %v errors, got %v", expected, s.Value)
 	}
 }
+
+type S23 struct {
+	v1 string
+	v2 int
+}
+
+func (s *S23) UnmarshalText(text []byte) error {
+	s.v1 = string(text)
+	return nil
+}
+
+// This test ensure that values of a struct are preserved when they are not modified
+// by the UnmarshalText method.
+func TestTextUnmarshalerInitialized(t *testing.T) {
+	data := map[string][]string{
+		"Value": []string{"hello"},
+	}
+
+	s := struct {
+		Value S23
+	}{
+		S23{v2: 100},
+	}
+	decoder := NewDecoder()
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal("Error while decoding:", err)
+	}
+	expected := S23{v1: "hello", v2: 100}
+	if expected != s.Value {
+		t.Errorf("Expected %v, got %v", expected, s)
+	}
+}


### PR DESCRIPTION
Hello,

We are using the schema package to decode parameters from HTTP requests to our API. We were using a specific commit until now, but while using the master branch we noticed that a fair amount of our tests were broken.

The tests are on a Limit structure we use. It has two fields : a current Value, and a configurable Max value. During the UnmarshalText method, we assign the value to the first field, and we check if it's under or equal the Max value. If it's not, we send back an error. The problem we had is that the Max value, set before the call when we initialize the structure, was at 0 instead of 1000 for example, hence raising an error in a lot of tests.

While digging in your code I found that when the library wants to decode in a pointer value, it's always zeroed with the reflect.New(v.Type()). That was causing the issue on our side. In this pull request I'm trying to fix this by taking the existing value instead of a new, zeroed one. It fixed our problems, and did not break your tests. I also wrote a simple test for your package to ensure that this behaviour is not broken.

Feel free to tell me if this PR is relevant or not.

Best regards,

TP