### PR TITLE
Fine grained decoding error

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -122,7 +122,7 @@ func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix 
 				key = prefix + key
 			}
 			if isEmpty(f.typ, src[key]) {
-				return fmt.Errorf("%v is empty", key)
+				return EmptyFieldError{Key: key}
 			}
 		}
 	}
@@ -431,6 +431,15 @@ type UnknownKeyError struct {
 
 func (e UnknownKeyError) Error() string {
 	return fmt.Sprintf("schema: invalid path %q", e.Key)
+}
+
+// EmptyFieldError stores information about an empty required field.
+type EmptyFieldError struct {
+	Key string // required key in the source map.
+}
+
+func (e EmptyFieldError) Error() string {
+	return fmt.Sprintf("%v is empty", e.Key)
 }
 
 // MultiError stores multiple decoding errors.

--- a/decoder.go
+++ b/decoder.go
@@ -84,49 +84,80 @@ func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
 			errors[path] = UnknownKeyError{Key: path}
 		}
 	}
+	errors.merge(d.checkRequired(t, src))
 	if len(errors) > 0 {
 		return errors
 	}
-	return d.checkRequired(t, src, "")
+	return nil
 }
 
 // checkRequired checks whether required fields are empty
 //
-// check type t recursively if t has struct fields, and prefix is same as parsePath: in dotted notation
+// check type t recursively if t has struct fields.
 //
 // src is the source map for decoding, we use it here to see if those required fields are included in src
-func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string, prefix string) error {
+func (d *Decoder) checkRequired(t reflect.Type, src map[string][]string) MultiError {
+	m, errs := d.findRequiredFields(t, "", "")
+	for key, fields := range m {
+		if isEmptyFields(fields, src) {
+			errs[key] = EmptyFieldError{Key: key}
+		}
+	}
+	return errs
+}
+
+// findRequiredFields recursively searches the struct type t for required fields.
+//
+// canonicalPrefix and searchPrefix are used to resolve full paths in dotted notation
+// for nested struct fields. canonicalPrefix is a complete path which never omits
+// any embedded struct fields. searchPrefix is a user-friendly path which may omit
+// some embedded struct fields to point promoted fields.
+func (d *Decoder) findRequiredFields(t reflect.Type, canonicalPrefix, searchPrefix string) (map[string][]fieldWithPrefix, MultiError) {
 	struc := d.cache.get(t)
 	if struc == nil {
 		// unexpect, cache.get never return nil
-		return errors.New("cache fail")
+		return nil, MultiError{canonicalPrefix + "*": errors.New("cache fail")}
 	}
 
+	m := map[string][]fieldWithPrefix{}
+	errs := MultiError{}
 	for _, f := range struc.fields {
 		if f.typ.Kind() == reflect.Struct {
-			err := d.checkRequired(f.typ, src, prefix+f.alias+".")
-			if err != nil {
-				if !f.isAnonymous {
-					return err
+			fcprefix := canonicalPrefix + f.canonicalAlias + "."
+			for _, fspath := range f.paths(searchPrefix) {
+				fm, ferrs := d.findRequiredFields(f.typ, fcprefix, fspath+".")
+				for key, fields := range fm {
+					m[key] = append(m[key], fields...)
 				}
-				// check embedded parent field.
-				err2 := d.checkRequired(f.typ, src, prefix)
-				if err2 != nil {
-					return err
-				}
+				errs.merge(ferrs)
 			}
 		}
 		if f.isRequired {
-			key := f.alias
-			if prefix != "" {
-				key = prefix + key
-			}
-			if isEmpty(f.typ, src[key]) {
-				return EmptyFieldError{Key: key}
+			key := canonicalPrefix + f.canonicalAlias
+			m[key] = append(m[key], fieldWithPrefix{
+				fieldInfo: f,
+				prefix:    searchPrefix,
+			})
+		}
+	}
+	return m, errs
+}
+
+type fieldWithPrefix struct {
+	*fieldInfo
+	prefix string
+}
+
+// isEmptyFields returns true if all of specified fields are empty.
+func isEmptyFields(fields []fieldWithPrefix, src map[string][]string) bool {
+	for _, f := range fields {
+		for _, path := range f.paths(f.prefix) {
+			if !isEmpty(f.typ, src[path]) {
+				return false
 			}
 		}
 	}
-	return nil
+	return true
 }
 
 // isEmpty returns true if value is empty for specific type
@@ -462,4 +493,12 @@ func (e MultiError) Error() string {
 		return s + " (and 1 other error)"
 	}
 	return fmt.Sprintf("%s (and %d other errors)", s, len(e)-1)
+}
+
+func (e MultiError) merge(errors MultiError) {
+	for key, err := range errors {
+		if e[key] == nil {
+			e[key] = err
+		}
+	}
 }

--- a/decoder.go
+++ b/decoder.go
@@ -81,7 +81,7 @@ func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
 				errors[path] = err
 			}
 		} else if !d.ignoreUnknownKeys {
-			errors[path] = fmt.Errorf("schema: invalid path %q", path)
+			errors[path] = UnknownKeyError{Key: path}
 		}
 	}
 	if len(errors) > 0 {
@@ -422,6 +422,15 @@ func (e ConversionError) Error() string {
 	}
 
 	return output
+}
+
+// UnknownKeyError stores information about an unknown key in the source map.
+type UnknownKeyError struct {
+	Key string // key from the source map.
+}
+
+func (e UnknownKeyError) Error() string {
+	return fmt.Sprintf("schema: invalid path %q", e.Key)
 }
 
 // MultiError stores multiple decoding errors.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1513,6 +1513,9 @@ func TestRequiredField(t *testing.T) {
 		t.Errorf("error nil, b.e is empty expect")
 		return
 	}
+	if expected := `b.e is empty`; err.Error() != expected {
+		t.Errorf("got %q, want %q", err, expected)
+	}
 
 	// all fields ok
 	v["b.e"] = []string{"nonempty"}
@@ -1528,6 +1531,9 @@ func TestRequiredField(t *testing.T) {
 	if err == nil {
 		t.Errorf("error nil, f is empty expect")
 		return
+	}
+	if expected := `f is empty`; err.Error() != expected {
+		t.Errorf("got %q, want %q", err, expected)
 	}
 	v["f"] = []string{"nonempty"}
 
@@ -1546,6 +1552,9 @@ func TestRequiredField(t *testing.T) {
 	if err == nil {
 		t.Errorf("error nil, h is empty expect")
 		return
+	}
+	if expected := `h is empty`; err.Error() != expected {
+		t.Errorf("got %q, want %q", err, expected)
 	}
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1571,7 +1571,7 @@ func TestRequiredFieldIsMissingCorrectError(t *testing.T) {
 	v := map[string][]string{
 		"rm1aa": {"aaa"},
 	}
-	expectedError := "rm1bb is empty"
+	expectedError := "RM1S.rm1bb is empty"
 	err := NewDecoder().Decode(&a, v)
 	if err.Error() != expectedError {
 		t.Errorf("expected %v, got %v", expectedError, err)


### PR DESCRIPTION
I'd like to receive more fine-grained, comprehensive error information from Decoder.
I found #70 and addressed it in this PR by using `MultiError`.
In addition, new error types are added to help to know error causes without parsing error messages, and ambiguous keys in a source map are recognized as unknown keys to return an error instead of ignoring them silently.