### PR TITLE
Use IsZero interface if it exists

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -46,6 +46,12 @@ func isValidStructPointer(v reflect.Value) bool {
 }
 
 func isZero(v reflect.Value) bool {
+	// check if the value confirms to the isZero() interface
+	// if so: use that interface
+	if z, ok := v.Interface().(interface{ IsZero() bool }); ok {
+		return z.IsZero()
+	}
+
 	switch v.Kind() {
 	case reflect.Func:
 	case reflect.Map, reflect.Slice:

--- a/encoder.go
+++ b/encoder.go
@@ -91,12 +91,6 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 			continue
 		}
 
-		// Encode struct pointer types if the field is a valid pointer and a struct.
-		if isValidStructPointer(v.Field(i)) {
-			e.encode(v.Field(i).Elem(), dst)
-			continue
-		}
-
 		encFunc := typeEncoder(v.Field(i).Type(), e.regenc)
 
 		// Encode non-slice types and custom implementations immediately.
@@ -126,6 +120,12 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 
 		// Encode a slice.
 		if v.Field(i).Len() == 0 && opts.Contains("omitempty") {
+			continue
+		}
+
+		// Encode struct pointer types if the field is a valid pointer and a struct.
+		if isValidStructPointer(v.Field(i)) {
+			e.encode(v.Field(i).Elem(), dst)
 			continue
 		}
 


### PR DESCRIPTION
If the `IsZero() bool` interface exists (as in `time.Time`) use that. Also prevents a panic:

```
--- FAIL: TestIsZeroInterface (0.00s)
panic: reflect.Value.Interface: cannot return value obtained from unexported field or method [recovered]
	panic: reflect.Value.Interface: cannot return value obtained from unexported field or method

goroutine 59 [running]:
testing.tRunner.func1(0xc0000cd900)
	/home/leon/bin/go1.12/src/testing/testing.go:830 +0x388
panic(0x546dc0, 0x5ad5d0)
	/home/leon/bin/go1.12/src/runtime/panic.go:522 +0x1b5
reflect.valueInterface(0x546f00, 0xc0000eb560, 0xab, 0xc0000f0a01, 0x8b, 0xa)
	/home/leon/bin/go1.12/src/reflect/value.go:990 +0x1bf
reflect.Value.Interface(...)
	/home/leon/bin/go1.12/src/reflect/value.go:979
github.com/gorilla/schema.isZero(0x546f00, 0xc0000eb560, 0xab, 0x0)
	/home/leon/Workspaces/go/src/github.com/gorilla/schema/encoder.go:69 +0x1ae
github.com/gorilla/schema.isZero(0x57a9c0, 0xc0000eb560, 0x99, 0x0)
	/home/leon/Workspaces/go/src/github.com/gorilla/schema/encoder.go:63 +0x2e8
github.com/gorilla/schema.(*Encoder).encode(0xc0000739e8, 0x5672c0, 0xc0000eb560, 0x99, 0xc000073ab0, 0xc0000eb560, 0xc00008ab78)
	/home/leon/Workspaces/go/src/github.com/gorilla/schema/encoder.go:100 +0x624
github.com/gorilla/schema.(*Encoder).Encode(0xc00008a9e8, 0x5672c0, 0xc0000eb560, 0xc00008aab0, 0x4, 0x5)
	/home/leon/Workspaces/go/src/github.com/gorilla/schema/encoder.go:29 +0xb4
github.com/gorilla/schema.TestIsZeroInterface(0xc0000cd900)
	/home/leon/Workspaces/go/src/github.com/gorilla/schema/encoder_test.go:441 +0x46f
testing.tRunner(0xc0000cd900, 0x589a68)
	/home/leon/bin/go1.12/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/home/leon/bin/go1.12/src/testing/testing.go:916 +0x357
exit status 2
FAIL	github.com/gorilla/schema	0.005s
```