### PR TITLE
[Reopen] Support custom converter from struct field names to form fields (callback)

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -26,11 +26,11 @@ func newCache() *cache {
 
 // cache caches meta-data about a struct.
 type cache struct {
-	l             sync.RWMutex
-	m             map[reflect.Type]*structInfo
-	regconv       map[reflect.Type]Converter
-	tag           string
-	nameConverter NameConverter
+	l               sync.RWMutex
+	m               map[reflect.Type]*structInfo
+	regconv         map[reflect.Type]Converter
+	tag             string
+	fieldNameMapper FieldNameMapper
 }
 
 // registerConverter registers a converter function for a custom type.
@@ -279,8 +279,8 @@ func (c *cache) fieldAlias(field reflect.StructField, tagName string) (alias str
 		alias, options = parseTag(tag)
 	}
 	if alias == "" {
-		if c.nameConverter != nil {
-			alias = c.nameConverter(field.Name)
+		if c.fieldNameMapper != nil {
+			alias = c.fieldNameMapper(field.Name)
 		} else {
 			alias = field.Name
 		}

--- a/converter.go
+++ b/converter.go
@@ -11,9 +11,9 @@ import (
 
 type Converter func(string) reflect.Value
 
-// Custom converter for struct field names to form fields. It will be called if alias is empty. Converter func gets
+// Custom mapper for struct field names to form fields. It will be called if alias is empty. Mapper func gets
 // name of the struct field and returns name of the corresponding form field.
-type NameConverter func(string) string
+type FieldNameMapper func(string) string
 
 var (
 	invalidValue = reflect.Value{}

--- a/converter.go
+++ b/converter.go
@@ -11,6 +11,10 @@ import (
 
 type Converter func(string) reflect.Value
 
+// Custom converter for struct field names to form fields. It will be called if alias is empty. Converter func gets
+// name of the struct field and returns name of the corresponding form field.
+type NameConverter func(string) string
+
 var (
 	invalidValue = reflect.Value{}
 	boolType     = reflect.Bool

--- a/decoder.go
+++ b/decoder.go
@@ -59,6 +59,11 @@ func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) 
 	d.cache.regconv[reflect.TypeOf(value)] = converterFunc
 }
 
+// RegisterNameConverter registers custom converter from struct field names to form fields.
+func (d *Decoder) RegisterNameConverter(converterFunc NameConverter) {
+	d.cache.nameConverter = converterFunc
+}
+
 // Decode decodes a map[string][]string to a struct.
 //
 // The first parameter must be a pointer to a struct.

--- a/decoder.go
+++ b/decoder.go
@@ -59,9 +59,9 @@ func (d *Decoder) RegisterConverter(value interface{}, converterFunc Converter) 
 	d.cache.registerConverter(value, converterFunc)
 }
 
-// RegisterNameConverter registers custom converter from struct field names to form fields.
-func (d *Decoder) RegisterNameConverter(converterFunc NameConverter) {
-	d.cache.nameConverter = converterFunc
+// RegisterFieldMapper registers custom mapper from struct field names to form fields.
+func (d *Decoder) RegisterFieldMapper(mapperFunc FieldNameMapper) {
+	d.cache.fieldNameMapper = mapperFunc
 }
 
 // Decode decodes a map[string][]string to a struct.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1970,7 +1970,7 @@ func TestTextUnmarshalerEmpty(t *testing.T) {
 	}
 }
 
-// ------------------- Test custom name converter ---------------------------
+// ------------------- Test custom field name mapper ---------------------------
 
 type S23 struct {
 	FirstField         string
@@ -1978,7 +1978,7 @@ type S23 struct {
 	VeryLongThirdField string
 }
 
-func TestCustomNameConverter(t *testing.T) {
+func TestCustomFieldNameMapper(t *testing.T) {
 	data := map[string][]string{
 		"first_field":           []string{"first"},
 		"second_field":          []string{"second"},
@@ -1986,8 +1986,8 @@ func TestCustomNameConverter(t *testing.T) {
 		"very_long_third_field": []string{"third"},
 	}
 	d := NewDecoder()
-	// CamelCase to underscore converter
-	d.RegisterNameConverter(func(fieldName string) string {
+	// CamelCase to underscore mapper
+	d.RegisterFieldMapper(func(fieldName string) string {
 		var output []rune
 		for _, r := range fieldName {
 			if !unicode.IsLower(r) {
@@ -2003,7 +2003,7 @@ func TestCustomNameConverter(t *testing.T) {
 	})
 	out := &S23{}
 	d.Decode(out, data)
-	// check simple convertation
+	// check simple mapping
 	if out.FirstField != "first" {
 		t.Errorf("Expected 'first' got '%s'", out.FirstField)
 	}


### PR DESCRIPTION
Fixes #54, #55

I reopen the pull request #55 that adds custom field name mapper. I changed the followings, but others are same to the original pull request. 

1. Merge master branch and resolve conflicts.
2. Rename type and function names according to the following comments.
    - https://github.com/gorilla/schema/pull/55#discussion_r53386801
    - https://github.com/gorilla/schema/pull/55#discussion_r53386803