### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gorilla/schema
+
+go 1.12


### PR DESCRIPTION
Fixes #

**Summary of Changes**

1. Add a go.mod. The newest golang is 1.13. But I see other repos under `gorilla` uses 1.12, so I use 1.12 here.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
