### PR TITLE
feat: throw error for required fields while encoding

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -100,6 +100,11 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 				continue
 			}
 
+			if opts.Contains("required") && isZero(v.Field(i)) {
+				errors[v.Field(i).Type().String()] = fmt.Errorf("schema: required field not given for %s", name)
+				continue
+			}
+
 			dst[name] = append(dst[name], value)
 			continue
 		}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -79,6 +79,12 @@ type E3 struct {
 	F15 Aa      `schema:"f15"`
 }
 
+type E7 struct {
+	F01 int `schema:"f01,required"`
+	F02 int `schema:"f02"`
+	F03 int `schema:"f03"`
+}
+
 // Test compatibility with default decoder types.
 func TestCompat(t *testing.T) {
 	src := &E3{
@@ -137,6 +143,19 @@ func TestEmpty(t *testing.T) {
 
 	valExists(t, "f03", "three", vals)
 	valNotExists(t, "f04", vals)
+}
+
+func TestRequired(t *testing.T) {
+	s := &E7{
+		F02: 2,
+		F03: 3,
+	}
+	vals := make(map[string][]string)
+	err := NewEncoder().Encode(s, vals)
+
+	if err == nil {
+		t.Error("Required element didn't throw error.")
+	}
 }
 
 func TestStruct(t *testing.T) {


### PR DESCRIPTION
**Summary of Changes**

1. Throw error for required fields, that are zero.
2. Add tests for that functionality.

I decided to check `omitempty` first and ignore `required` because they exclude each other per definition. I want to use the library for a REST-Client and need this to be checked.
