### PR TITLE
fixed panic on pointers to embedded structs

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -193,7 +193,7 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 		if v.Type().Kind() == reflect.Struct {
 			for i := 0; i < v.NumField(); i++ {
 				field := v.Field(i)
-				if field.Type().Kind() == reflect.Ptr && v.Type().Field(i).Anonymous == true {
+				if field.Type().Kind() == reflect.Ptr && field.IsNil() && v.Type().Field(i).Anonymous == true {
 					field.Set(reflect.New(field.Type().Elem()))
 				}
 			}

--- a/decoder.go
+++ b/decoder.go
@@ -188,6 +188,17 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 			}
 			v = v.Elem()
 		}
+
+		// alloc embedded structs
+		if v.Type().Kind() == reflect.Struct {
+			for i := 0; i < v.NumField(); i++ {
+				field := v.Field(i)
+				if field.Type().Kind() == reflect.Ptr && v.Type().Field(i).Anonymous == true {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
+			}
+		}
+
 		v = v.FieldByName(name)
 	}
 	// Don't even bother for unexported fields.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1985,3 +1985,40 @@ func TestTextUnmarshalerEmpty(t *testing.T) {
 		t.Errorf("Expected %v errors, got %v", expected, s.Value)
 	}
 }
+
+type S23n struct {
+	F2 string `schema:"F2"`
+}
+
+type S23e struct {
+	*S23n
+	F1 string `schema:"F1"`
+}
+
+type S23 []*S23e
+
+func TestUnmashalPointerToEmbedded(t *testing.T) {
+	data := map[string][]string{
+		"A.0.F2": []string{"raw a"},
+	}
+
+	// Implements encoding.TextUnmarshaler, should not throw invalid path
+	// error.
+	s := struct {
+		Value S23 `schema:"A"`
+	}{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal("Error while decoding:", err)
+	}
+
+	expected := S23{
+		&S23e{
+			S23n: &S23n{"raw a"},
+		},
+	}
+	if !reflect.DeepEqual(expected, s.Value) {
+		t.Errorf("Expected %v errors, got %v", expected, s.Value)
+	}
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1988,6 +1988,7 @@ func TestTextUnmarshalerEmpty(t *testing.T) {
 
 type S23n struct {
 	F2 string `schema:"F2"`
+	F3 string `schema:"F3"`
 }
 
 type S23e struct {
@@ -2000,6 +2001,7 @@ type S23 []*S23e
 func TestUnmashalPointerToEmbedded(t *testing.T) {
 	data := map[string][]string{
 		"A.0.F2": []string{"raw a"},
+		"A.0.F3": []string{"raw b"},
 	}
 
 	// Implements encoding.TextUnmarshaler, should not throw invalid path
@@ -2015,7 +2017,7 @@ func TestUnmashalPointerToEmbedded(t *testing.T) {
 
 	expected := S23{
 		&S23e{
-			S23n: &S23n{"raw a"},
+			S23n: &S23n{"raw a", "raw b"},
 		},
 	}
 	if !reflect.DeepEqual(expected, s.Value) {


### PR DESCRIPTION
**Summary of Changes**

```
 type Example struct {
    *Embedded
     Field string
 }
```

When a struct contains a pointer to an embedded struct, the code panics because the fields in the embedded struct are not allocated.
Part of the stack trace:

```
reflect: indirection through nil pointer to embedded struct goroutine 90 [running]:
reflect.Value.FieldByIndex(0x1bbc4e0, 0xc0003e7ec0, 0x199, 0xc0002c6e40, 0x2, 0x2, 0x0, 0x1d93dc0, 0x1aeb9c0)
	/usr/local/go/src/reflect/value.go:876 +0x4f2
reflect.Value.FieldByName(0x1bbc4e0, 0xc0003e7ec0, 0x199, 0x1b54e80, 0x4, 0x199, 0x15afec3, 0xc0003e7eba)
	/usr/local/go/src/reflect/value.go:892 +0x116
github.com/gorilla/schema.(*Decoder).decode(0xc0002b9e40, 0x1b36ae0, 0xc0000d8280, 0x196, 0xc0004d0799, 0xc, 0xc0000e6ca8, 0x1, 0x1, 0xc0002b9e60, ...)
	/Users/grzegorzwyszyski/Workspace/gopath/pkg/mod/github.com/gorilla/schema@v1.1.0/decoder.go:185 +0x212
github.com/gorilla/schema.(*Decoder).decode(0xc0002b9e40, 0x1bf0600, 0xc00032e1e0, 0x199, 0xc0004d0799, 0xc, 0xc0000e6c80, 0x2, 0x2, 0xc0002b9e60, ...)
	/Users/grzegorzwyszyski/Workspace/gopath/pkg/mod/github.com/gorilla/schema@v1.1.0/decoder.go:213 +0x28aa
github.com/gorilla/schema.(*Decoder).Decode(0xc0002b9e40, 0x1b36a60, 0xc00032e1e0, 0xc00021f200, 0x2, 0x3b)
	/Users/grzegorzwyszyski/Workspace/gopath/pkg/mod/github.com/gorilla/schema@v1.1.0/decoder.go:80 +0x3c6
```

Panic can be reproduced using the test provided by this pull request.