### PR TITLE
fix nested structs encoding

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -188,6 +188,17 @@ func (d *Decoder) decode(v reflect.Value, path string, parts []pathPart, values 
 			}
 			v = v.Elem()
 		}
+
+		// alloc embedded structs
+		if v.Type().Kind() == reflect.Struct {
+			for i := 0; i < v.NumField(); i++ {
+				field := v.Field(i)
+				if field.Type().Kind() == reflect.Ptr && field.IsNil() && v.Type().Field(i).Anonymous == true {
+					field.Set(reflect.New(field.Type().Elem()))
+				}
+			}
+		}
+
 		v = v.FieldByName(name)
 	}
 	// Don't even bother for unexported fields.

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1985,3 +1985,42 @@ func TestTextUnmarshalerEmpty(t *testing.T) {
 		t.Errorf("Expected %v errors, got %v", expected, s.Value)
 	}
 }
+
+type S23n struct {
+	F2 string `schema:"F2"`
+	F3 string `schema:"F3"`
+}
+
+type S23e struct {
+	*S23n
+	F1 string `schema:"F1"`
+}
+
+type S23 []*S23e
+
+func TestUnmashalPointerToEmbedded(t *testing.T) {
+	data := map[string][]string{
+		"A.0.F2": []string{"raw a"},
+		"A.0.F3": []string{"raw b"},
+	}
+
+	// Implements encoding.TextUnmarshaler, should not throw invalid path
+	// error.
+	s := struct {
+		Value S23 `schema:"A"`
+	}{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal("Error while decoding:", err)
+	}
+
+	expected := S23{
+		&S23e{
+			S23n: &S23n{"raw a", "raw b"},
+		},
+	}
+	if !reflect.DeepEqual(expected, s.Value) {
+		t.Errorf("Expected %v errors, got %v", expected, s.Value)
+	}
+}

--- a/encoder.go
+++ b/encoder.go
@@ -57,6 +57,13 @@ func isZero(v reflect.Value) bool {
 		}
 		return z
 	case reflect.Struct:
+		type zero interface {
+			IsZero() bool
+		}
+		if v.Type().Implements(reflect.TypeOf((*zero)(nil)).Elem()) {
+			iz := v.MethodByName("IsZero").Call([]reflect.Value{})[0]
+			return iz.Interface().(bool)
+		}
 		z := true
 		for i := 0; i < v.NumField(); i++ {
 			z = z && isZero(v.Field(i))

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -52,7 +52,7 @@ func TestFilled(t *testing.T) {
 	valExists(t, "f07", "seven", vals)
 	valExists(t, "f08", "8", vals)
 	valExists(t, "f09", "1.618000", vals)
-	valExists(t, "F12", "12", vals)
+	valExists(t, "F11.F12", "12", vals)
 
 	emptyErr := MultiError{}
 	if errs.Error() == emptyErr.Error() {
@@ -288,7 +288,7 @@ func TestEncoderOrder(t *testing.T) {
 	valExists(t, "simple_overridden", "one", v1)
 	valExists(t, "slice", "2", v1)
 	valExists(t, "slice_overridden", "two", v1)
-	valExists(t, "nr", "3", v1)
+	valExists(t, "struct.nr", "3", v1)
 	valExists(t, "struct_overridden", "three", v1)
 }
 
@@ -371,7 +371,7 @@ func TestEncoderWithOmitempty(t *testing.T) {
 	valNotExists(t, "f04", vals)
 	valNotExists(t, "f05", vals)
 	valNotExists(t, "f06", vals)
-	valExists(t, "f0601", "test", vals)
+	valExists(t, "f07.f0601", "test", vals)
 	valNotExists(t, "f08", vals)
 	valsExist(t, "f09", []string{"test"}, vals)
 }
@@ -390,7 +390,7 @@ func TestStructPointer(t *testing.T) {
 
 	encoder := NewEncoder()
 	encoder.Encode(&s, vals)
-	valExists(t, "F12", "2", vals)
+	valExists(t, "F01.F12", "2", vals)
 	valExists(t, "F02", "null", vals)
 	valNotExists(t, "F03", vals)
 }
@@ -462,4 +462,30 @@ func TestRegisterEncoderStructIsZero(t *testing.T) {
 			t.Error("expected tim1 not to be present")
 		}
 	}
+}
+
+type E7 struct {
+	F01 string
+	F02 inner
+	F03 inner `schema:"-"`
+}
+
+func TestEncodeForNestedType(t *testing.T) {
+	s := E7{
+		F01: "f01",
+		F02: inner{F12: 12},
+		F03: inner{F12: 12},
+	}
+
+	encoded := map[string][]string{}
+	encoder := NewEncoder()
+	err := encoder.Encode(s, encoded)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	valExists(t, "F01", "f01", encoded)
+	valExists(t, "F02.F12", "12", encoded)
+	valNotExists(t, "F03.F12", encoded)
 }


### PR DESCRIPTION
Fixes #118

**Summary of Changes**

1. Encoding of nested structs creates keys with nested, dot separated, path information. Similar to how decoding works

At the moment there is a difference to how encoding/decoding works with nested structs. Encoding seems to ignore 'nested' struct Information and 'flattens' the key. This pull request fixes that behavior.  


