### PR TITLE
Remove "more examples"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ The supported field types in the struct are:
 
 Unsupported types are simply ignored, however custom types can be registered to be converted.
 
-More examples are available on the Gorilla website: https://www.gorillatoolkit.org/pkg/schema
-
 ## License
 
 BSD licensed. See the LICENSE file for details.


### PR DESCRIPTION
The "more example on website" link leads back to this repo, making the link redundant.
