### PR TITLE
if exist customized converter, do not need to parse the special case

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -63,7 +63,10 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 		}
 		// Valid field. Append index.
 		path = append(path, field.name)
-		if field.isSliceOfStructs && (!field.unmarshalerInfo.IsValid || (field.unmarshalerInfo.IsValid && field.unmarshalerInfo.IsSliceElement)) {
+
+		// if exist customized coverter, do not parse the special case
+		_, ok := c.regconv[field.typ]
+		if !ok && field.isSliceOfStructs && (!field.unmarshalerInfo.IsValid || (field.unmarshalerInfo.IsValid && field.unmarshalerInfo.IsSliceElement)) {
 			// Parse a special case: slices of structs.
 			// i+1 must be the slice index.
 			//


### PR DESCRIPTION
Fixes #
if exist customized converter, do not need to parse the special case
**Summary of Changes**

1. check if there is a customized converter for the type
2. only when there are no converters for the type check if it is the special case3.

