### PR TITLE
Do not encode unexported fields

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -87,7 +87,22 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string) error {
 	errors := MultiError{}
 
 	for i := 0; i < v.NumField(); i++ {
-		name, opts := fieldAlias(t.Field(i), e.cache.tag)
+		sf := t.Field(i)
+
+		if sf.Anonymous {
+			t := sf.Type
+			if t.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+
+			if t.Kind() != reflect.Struct && sf.PkgPath != "" {
+				continue // ignore unexported struct types
+			}
+		} else if sf.PkgPath != "" {
+			continue // ignore unexported fields
+		}
+
+		name, opts := fieldAlias(sf, e.cache.tag)
 		if name == "-" {
 			continue
 		}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -463,3 +463,27 @@ func TestRegisterEncoderStructIsZero(t *testing.T) {
 		}
 	}
 }
+
+func TestUnexportedFields(t *testing.T) {
+	type S1 struct {
+		Exported   string `schema:"exported"`
+		unexported string
+	}
+
+	ss := S1{
+		Exported:   "string",
+		unexported: "another string",
+	}
+
+	vals := map[string][]string{}
+
+	encoder := NewEncoder()
+
+	err := encoder.Encode(ss, vals)
+	if err != nil {
+		t.Errorf("Encoder has non-nil error: %v", err)
+	}
+
+	valExists(t, "exported", ss.Exported, vals)
+	valNotExists(t, "unexported", vals)
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -154,10 +154,10 @@ func TestSlices(t *testing.T) {
 	type oneAsWord int
 	ones := []oneAsWord{1, 2}
 	s1 := &struct {
-		ones     []oneAsWord `schema:"ones"`
-		ints     []int       `schema:"ints"`
-		nonempty []int       `schema:"nonempty"`
-		empty    []int       `schema:"empty,omitempty"`
+		Ones     []oneAsWord `schema:"ones"`
+		Ints     []int       `schema:"ints"`
+		Nonempty []int       `schema:"nonempty"`
+		Empty    []int       `schema:"empty,omitempty"`
 	}{ones, []int{1, 1}, []int{}, []int{}}
 	vals := make(map[string][]string)
 
@@ -223,61 +223,61 @@ func TestCompatSlices(t *testing.T) {
 }
 
 func TestRegisterEncoder(t *testing.T) {
-	type oneAsWord int
-	type twoAsWord int
-	type oneSliceAsWord []int
+	type OneAsWord int
+	type TwoAsWord int
+	type OneSliceAsWord []int
 
 	s1 := &struct {
-		oneAsWord
-		twoAsWord
-		oneSliceAsWord
+		OneAsWord
+		TwoAsWord
+		OneSliceAsWord
 	}{1, 2, []int{1, 1}}
 	v1 := make(map[string][]string)
 
 	encoder := NewEncoder()
-	encoder.RegisterEncoder(s1.oneAsWord, func(v reflect.Value) string { return "one" })
-	encoder.RegisterEncoder(s1.twoAsWord, func(v reflect.Value) string { return "two" })
-	encoder.RegisterEncoder(s1.oneSliceAsWord, func(v reflect.Value) string { return "one" })
+	encoder.RegisterEncoder(s1.OneAsWord, func(v reflect.Value) string { return "one" })
+	encoder.RegisterEncoder(s1.TwoAsWord, func(v reflect.Value) string { return "two" })
+	encoder.RegisterEncoder(s1.OneSliceAsWord, func(v reflect.Value) string { return "one" })
 
 	err := encoder.Encode(s1, v1)
 	if err != nil {
 		t.Errorf("Encoder has non-nil error: %v", err)
 	}
 
-	valExists(t, "oneAsWord", "one", v1)
-	valExists(t, "twoAsWord", "two", v1)
-	valExists(t, "oneSliceAsWord", "one", v1)
+	valExists(t, "OneAsWord", "one", v1)
+	valExists(t, "TwoAsWord", "two", v1)
+	valExists(t, "OneSliceAsWord", "one", v1)
 }
 
 func TestEncoderOrder(t *testing.T) {
-	type builtinEncoderSimple int
-	type builtinEncoderSimpleOverridden int
-	type builtinEncoderSlice []int
-	type builtinEncoderSliceOverridden []int
-	type builtinEncoderStruct struct{ nr int }
-	type builtinEncoderStructOverridden struct{ nr int }
+	type BuiltinEncoderSimple int
+	type BuiltinEncoderSimpleOverridden int
+	type BuiltinEncoderSlice []int
+	type BuiltinEncoderSliceOverridden []int
+	type BuiltinEncoderStruct struct{ Nr int }
+	type BuiltinEncoderStructOverridden struct{ Nr int }
 
 	s1 := &struct {
-		builtinEncoderSimple           `schema:"simple"`
-		builtinEncoderSimpleOverridden `schema:"simple_overridden"`
-		builtinEncoderSlice            `schema:"slice"`
-		builtinEncoderSliceOverridden  `schema:"slice_overridden"`
-		builtinEncoderStruct           `schema:"struct"`
-		builtinEncoderStructOverridden `schema:"struct_overridden"`
+		BuiltinEncoderSimple           `schema:"simple"`
+		BuiltinEncoderSimpleOverridden `schema:"simple_overridden"`
+		BuiltinEncoderSlice            `schema:"slice"`
+		BuiltinEncoderSliceOverridden  `schema:"slice_overridden"`
+		BuiltinEncoderStruct           `schema:"struct"`
+		BuiltinEncoderStructOverridden `schema:"struct_overridden"`
 	}{
 		1,
 		1,
 		[]int{2},
 		[]int{2},
-		builtinEncoderStruct{3},
-		builtinEncoderStructOverridden{3},
+		BuiltinEncoderStruct{3},
+		BuiltinEncoderStructOverridden{3},
 	}
 	v1 := make(map[string][]string)
 
 	encoder := NewEncoder()
-	encoder.RegisterEncoder(s1.builtinEncoderSimpleOverridden, func(v reflect.Value) string { return "one" })
-	encoder.RegisterEncoder(s1.builtinEncoderSliceOverridden, func(v reflect.Value) string { return "two" })
-	encoder.RegisterEncoder(s1.builtinEncoderStructOverridden, func(v reflect.Value) string { return "three" })
+	encoder.RegisterEncoder(s1.BuiltinEncoderSimpleOverridden, func(v reflect.Value) string { return "one" })
+	encoder.RegisterEncoder(s1.BuiltinEncoderSliceOverridden, func(v reflect.Value) string { return "two" })
+	encoder.RegisterEncoder(s1.BuiltinEncoderStructOverridden, func(v reflect.Value) string { return "three" })
 
 	err := encoder.Encode(s1, v1)
 	if err != nil {
@@ -288,7 +288,7 @@ func TestEncoderOrder(t *testing.T) {
 	valExists(t, "simple_overridden", "one", v1)
 	valExists(t, "slice", "2", v1)
 	valExists(t, "slice_overridden", "two", v1)
-	valExists(t, "nr", "3", v1)
+	valExists(t, "Nr", "3", v1)
 	valExists(t, "struct_overridden", "three", v1)
 }
 


### PR DESCRIPTION
Fixes #167

**Summary of Changes**

1. unexported fields not encoded
2. fields from anonymous unexported structs too
3. new test
