### PR TITLE
Add options to encode slice to string with separators

### DIFF
--- a/encoder_test.go
+++ b/encoder_test.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -462,4 +463,35 @@ func TestRegisterEncoderStructIsZero(t *testing.T) {
 			t.Error("expected tim1 not to be present")
 		}
 	}
+}
+
+func TestSliceSeparatorEncoding(t *testing.T) {
+	type S1 struct {
+		Field     []string `schema:"field"`
+		Space     []string `schema:"space,space"`
+		Comma     []string `schema:"comma,comma"`
+		Semicolon []string `schema:"semicolon,semicolon"`
+	}
+
+	ss := S1{
+		Field:     []string{"field1", "field2"},
+		Space:     []string{"space1", "space2"},
+		Comma:     []string{"comma1", "comma2"},
+		Semicolon: []string{"semicolon1", "semicolon2"},
+	}
+
+	vals := map[string][]string{}
+
+	encoder := NewEncoder()
+
+	err := encoder.Encode(ss, vals)
+	if err != nil {
+		t.Errorf("Encoder has non-nil error: %v", err)
+	}
+
+	valsExist(t, "field", ss.Field, vals)
+
+	valExists(t, "space", strings.Join(ss.Space, " "), vals)
+	valExists(t, "comma", strings.Join(ss.Comma, ","), vals)
+	valExists(t, "semicolon", strings.Join(ss.Semicolon, ";"), vals)
 }


### PR DESCRIPTION
Fixes #168 

Summary of changes:
1. Tag options now may contain one of the `comma`, `space` or `semicolon`
2. When present, slice will be encoded to string field without escaping
3. Slice of strings now allocated once
4. New test with new encoding options

Decoder part not implemented.