### PR TITLE
Add default tag

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -17,19 +17,21 @@ var errInvalidPath = errors.New("schema: invalid path")
 // newCache returns a new cache.
 func newCache() *cache {
 	c := cache{
-		m:       make(map[reflect.Type]*structInfo),
-		regconv: make(map[reflect.Type]Converter),
-		tag:     "schema",
+		m:          make(map[reflect.Type]*structInfo),
+		regconv:    make(map[reflect.Type]Converter),
+		tag:        "schema",
+		defaultTag: "default",
 	}
 	return &c
 }
 
 // cache caches meta-data about a struct.
 type cache struct {
-	l       sync.RWMutex
-	m       map[reflect.Type]*structInfo
-	regconv map[reflect.Type]Converter
-	tag     string
+	l          sync.RWMutex
+	m          map[reflect.Type]*structInfo
+	regconv    map[reflect.Type]Converter
+	tag        string
+	defaultTag string
 }
 
 // registerConverter registers a converter function for a custom type.
@@ -197,6 +199,7 @@ func (c *cache) createField(field reflect.StructField, parentAlias string) *fiel
 		isSliceOfStructs: isSlice && isStruct,
 		isAnonymous:      field.Anonymous,
 		isRequired:       options.Contains("required"),
+		defaultValue:     field.Tag.Get(c.defaultTag),
 	}
 }
 
@@ -246,8 +249,9 @@ type fieldInfo struct {
 	// isSliceOfStructs indicates if the field type is a slice of structs.
 	isSliceOfStructs bool
 	// isAnonymous indicates whether the field is embedded in the struct.
-	isAnonymous bool
-	isRequired  bool
+	isAnonymous  bool
+	isRequired   bool
+	defaultValue string
 }
 
 func (f *fieldInfo) paths(prefix string) []string {

--- a/cache.go
+++ b/cache.go
@@ -309,10 +309,7 @@ func (o tagOptions) Contains(option string) bool {
 func (o tagOptions) getDefaultOptionValue() string {
 	for _, s := range o {
 		if strings.HasPrefix(s, "default:") {
-			if t := strings.Split(s, ":"); len(t) > 0 {
-				return t[1]
-			}
-			break
+			return strings.Split(s, ":")[1]
 		}
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -17,21 +17,19 @@ var errInvalidPath = errors.New("schema: invalid path")
 // newCache returns a new cache.
 func newCache() *cache {
 	c := cache{
-		m:          make(map[reflect.Type]*structInfo),
-		regconv:    make(map[reflect.Type]Converter),
-		tag:        "schema",
-		defaultTag: "default",
+		m:       make(map[reflect.Type]*structInfo),
+		regconv: make(map[reflect.Type]Converter),
+		tag:     "schema",
 	}
 	return &c
 }
 
 // cache caches meta-data about a struct.
 type cache struct {
-	l          sync.RWMutex
-	m          map[reflect.Type]*structInfo
-	regconv    map[reflect.Type]Converter
-	tag        string
-	defaultTag string
+	l       sync.RWMutex
+	m       map[reflect.Type]*structInfo
+	regconv map[reflect.Type]Converter
+	tag     string
 }
 
 // registerConverter registers a converter function for a custom type.
@@ -199,7 +197,7 @@ func (c *cache) createField(field reflect.StructField, parentAlias string) *fiel
 		isSliceOfStructs: isSlice && isStruct,
 		isAnonymous:      field.Anonymous,
 		isRequired:       options.Contains("required"),
-		defaultValue:     field.Tag.Get(c.defaultTag),
+		defaultValue:     options.getDefaultOptionValue(),
 	}
 }
 
@@ -306,4 +304,17 @@ func (o tagOptions) Contains(option string) bool {
 		}
 	}
 	return false
+}
+
+func (o tagOptions) getDefaultOptionValue() string {
+	for _, s := range o {
+		if strings.HasPrefix(s, "default:") {
+			if t := strings.Split(s, ":"); len(t) > 0 {
+				return t[1]
+			}
+			break
+		}
+	}
+
+	return ""
 }

--- a/converter.go
+++ b/converter.go
@@ -143,3 +143,52 @@ func convertUint64(value string) reflect.Value {
 	}
 	return invalidValue
 }
+
+func convertPointer(k reflect.Kind, value string) reflect.Value {
+	switch k {
+	case boolType:
+		v := convertBool(value).Bool()
+		return reflect.ValueOf(&v)
+	case float32Type:
+		v := float32(convertFloat32(value).Float())
+		return reflect.ValueOf(&v)
+	case float64Type:
+		v := float64(convertFloat64(value).Float())
+		return reflect.ValueOf(&v)
+	case intType:
+		v := int(convertInt(value).Int())
+		return reflect.ValueOf(&v)
+	case int8Type:
+		v := int8(convertInt8(value).Int())
+		return reflect.ValueOf(&v)
+	case int16Type:
+		v := int16(convertInt16(value).Int())
+		return reflect.ValueOf(&v)
+	case int32Type:
+		v := int32(convertInt32(value).Int())
+		return reflect.ValueOf(&v)
+	case int64Type:
+		v := int64(convertInt64(value).Int())
+		return reflect.ValueOf(&v)
+	case stringType:
+		v := convertString(value).String()
+		return reflect.ValueOf(&v)
+	case uintType:
+		v := uint(convertUint(value).Uint())
+		return reflect.ValueOf(&v)
+	case uint8Type:
+		v := uint8(convertUint8(value).Uint())
+		return reflect.ValueOf(&v)
+	case uint16Type:
+		v := uint16(convertUint16(value).Uint())
+		return reflect.ValueOf(&v)
+	case uint32Type:
+		v := uint32(convertUint32(value).Uint())
+		return reflect.ValueOf(&v)
+	case uint64Type:
+		v := uint64(convertUint64(value).Uint())
+		return reflect.ValueOf(&v)
+	}
+
+	return invalidValue
+}

--- a/converter.go
+++ b/converter.go
@@ -147,47 +147,75 @@ func convertUint64(value string) reflect.Value {
 func convertPointer(k reflect.Kind, value string) reflect.Value {
 	switch k {
 	case boolType:
-		v := convertBool(value).Bool()
-		return reflect.ValueOf(&v)
+		if v := convertBool(value); v.IsValid() {
+			converted := v.Bool()
+			return reflect.ValueOf(&converted)
+		}
 	case float32Type:
-		v := float32(convertFloat32(value).Float())
-		return reflect.ValueOf(&v)
+		if v := convertFloat32(value); v.IsValid() {
+			converted := float32(v.Float())
+			return reflect.ValueOf(&converted)
+		}
 	case float64Type:
-		v := float64(convertFloat64(value).Float())
-		return reflect.ValueOf(&v)
+		if v := convertFloat64(value); v.IsValid() {
+			converted := float64(v.Float())
+			return reflect.ValueOf(&converted)
+		}
 	case intType:
-		v := int(convertInt(value).Int())
-		return reflect.ValueOf(&v)
+		if v := convertInt(value); v.IsValid() {
+			converted := int(v.Int())
+			return reflect.ValueOf(&converted)
+		}
 	case int8Type:
-		v := int8(convertInt8(value).Int())
-		return reflect.ValueOf(&v)
+		if v := convertInt8(value); v.IsValid() {
+			converted := int8(v.Int())
+			return reflect.ValueOf(&converted)
+		}
 	case int16Type:
-		v := int16(convertInt16(value).Int())
-		return reflect.ValueOf(&v)
+		if v := convertInt16(value); v.IsValid() {
+			converted := int16(v.Int())
+			return reflect.ValueOf(&converted)
+		}
 	case int32Type:
-		v := int32(convertInt32(value).Int())
-		return reflect.ValueOf(&v)
+		if v := convertInt32(value); v.IsValid() {
+			converted := int32(v.Int())
+			return reflect.ValueOf(&converted)
+		}
 	case int64Type:
-		v := int64(convertInt64(value).Int())
-		return reflect.ValueOf(&v)
+		if v := convertInt64(value); v.IsValid() {
+			converted := int64(v.Int())
+			return reflect.ValueOf(&converted)
+		}
 	case stringType:
-		v := convertString(value).String()
-		return reflect.ValueOf(&v)
+		if v := convertString(value); v.IsValid() {
+			converted := v.String()
+			return reflect.ValueOf(&converted)
+		}
 	case uintType:
-		v := uint(convertUint(value).Uint())
-		return reflect.ValueOf(&v)
+		if v := convertUint(value); v.IsValid() {
+			converted := uint(v.Uint())
+			return reflect.ValueOf(&converted)
+		}
 	case uint8Type:
-		v := uint8(convertUint8(value).Uint())
-		return reflect.ValueOf(&v)
+		if v := convertUint8(value); v.IsValid() {
+			converted := uint8(v.Uint())
+			return reflect.ValueOf(&converted)
+		}
 	case uint16Type:
-		v := uint16(convertUint16(value).Uint())
-		return reflect.ValueOf(&v)
+		if v := convertUint16(value); v.IsValid() {
+			converted := uint16(v.Uint())
+			return reflect.ValueOf(&converted)
+		}
 	case uint32Type:
-		v := uint32(convertUint32(value).Uint())
-		return reflect.ValueOf(&v)
+		if v := convertUint32(value); v.IsValid() {
+			converted := uint32(v.Uint())
+			return reflect.ValueOf(&converted)
+		}
 	case uint64Type:
-		v := uint64(convertUint64(value).Uint())
-		return reflect.ValueOf(&v)
+		if v := convertUint64(value); v.IsValid() {
+			converted := uint64(v.Uint())
+			return reflect.ValueOf(&converted)
+		}
 	}
 
 	return invalidValue

--- a/decoder.go
+++ b/decoder.go
@@ -117,12 +117,12 @@ func (d *Decoder) setDefaults(t reflect.Type, v reflect.Value) MultiError {
 			errs.merge(MultiError{"default-" + f.name: errors.New("required fields cannot have a default value")})
 		} else if f.defaultValue != "" && vCurrent.IsZero() && !f.isRequired {
 			if f.typ.Kind() == reflect.Struct || f.typ.Kind() == reflect.Slice {
-				errs.merge(MultiError{"default-" + f.name: errors.New("default tag is supported only on: bool, float variants, string, unit variants types or their corresponding pointers")})
+				errs.merge(MultiError{"default-" + f.name: errors.New("default option is supported only on: bool, float variants, string, unit variants types or their corresponding pointers")})
 			} else if f.typ.Kind() == reflect.Ptr {
 				t1 := f.typ.Elem()
 
 				if t1.Kind() == reflect.Struct || t1.Kind() == reflect.Slice {
-					errs.merge(MultiError{"default-" + f.name: errors.New("default tag is supported only on: bool, float variants, string, unit variants types or their corresponding pointers")})
+					errs.merge(MultiError{"default-" + f.name: errors.New("default option is supported only on: bool, float variants, string, unit variants types or their corresponding pointers")})
 				}
 
 				vCurrent.Set(convertPointer(t1.Kind(), f.defaultValue))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2058,7 +2058,15 @@ func TestUnmashalPointerToEmbedded(t *testing.T) {
 
 func TestDefaultValuesAreSet(t *testing.T) {
 
+	//TODO: Test nesting and update repos
+
+	type N struct {
+		S1 string `schema:"s1" default:"test1"`
+		I2 int    `schema:"i2" default:"22"`
+	}
+
 	type D struct {
+		N
 		S string  `schema:"s" default:"test1"`
 		I int     `schema:"i" default:"21"`
 		B bool    `schema:"b" default:"false"`
@@ -2077,6 +2085,10 @@ func TestDefaultValuesAreSet(t *testing.T) {
 	}
 
 	expected := D{
+		N: N{
+			S1: "test1",
+			I2: 22,
+		},
 		S: "test1",
 		I: 21,
 		B: false,
@@ -2089,6 +2101,7 @@ func TestDefaultValuesAreSet(t *testing.T) {
 	}
 
 	type P struct {
+		*N
 		S *string  `schema:"s" default:"test1"`
 		I *int     `schema:"i" default:"21"`
 		B *bool    `schema:"b" default:"false"`
@@ -2096,7 +2109,7 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		U *uint    `schema:"u" default:"1"`
 	}
 
-	p := P{}
+	p := P{N: &N{}}
 
 	if err := decoder.Decode(&p, data); err != nil {
 		t.Fatal("Error while decoding:", err)
@@ -2167,7 +2180,7 @@ func TestRequiredFieldsCannotHaveDefaults(t *testing.T) {
 
 	expected := "required fields cannot have a default value"
 
-	if err == nil || err.Error() != expected {
+	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("decoding should fail with error msg %s got %q", expected, err)
 	}
 
@@ -2190,7 +2203,7 @@ func TestDefaultsAreNotSupportedForStructsAndSlices(t *testing.T) {
 
 	expected := "default tag is supported only on: bool, float variants, string, unit variants types or their corresponding pointers"
 
-	if err == nil || err.Error() != expected {
+	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("decoding should fail with error msg %s got %q", expected, err)
 	}
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2058,20 +2058,18 @@ func TestUnmashalPointerToEmbedded(t *testing.T) {
 
 func TestDefaultValuesAreSet(t *testing.T) {
 
-	//TODO: Test nesting and update repos
-
 	type N struct {
-		S1 string `schema:"s1" default:"test1"`
-		I2 int    `schema:"i2" default:"22"`
+		S1 string `schema:"s1,default:test1"`
+		I2 int    `schema:"i2,default:22"`
 	}
 
 	type D struct {
 		N
-		S string  `schema:"s" default:"test1"`
-		I int     `schema:"i" default:"21"`
-		B bool    `schema:"b" default:"false"`
-		F float64 `schema:"f" default:"3.14"`
-		U uint    `schema:"u" default:"1"`
+		S string  `schema:"s,default:test1"`
+		I int     `schema:"i,default:21"`
+		B bool    `schema:"b,default:false"`
+		F float64 `schema:"f,default:3.14"`
+		U uint    `schema:"u,default:1"`
 	}
 
 	data := map[string][]string{}
@@ -2102,11 +2100,11 @@ func TestDefaultValuesAreSet(t *testing.T) {
 
 	type P struct {
 		*N
-		S *string  `schema:"s" default:"test1"`
-		I *int     `schema:"i" default:"21"`
-		B *bool    `schema:"b" default:"false"`
-		F *float64 `schema:"f" default:"3.14"`
-		U *uint    `schema:"u" default:"1"`
+		S *string  `schema:"s,default:test1"`
+		I *int     `schema:"i,default:21"`
+		B *bool    `schema:"b,default:false"`
+		F *float64 `schema:"f,default:3.14"`
+		U *uint    `schema:"u,default:1"`
 	}
 
 	p := P{N: &N{}}
@@ -2130,11 +2128,11 @@ func TestDefaultValuesAreSet(t *testing.T) {
 
 func TestDefaultValuesAreIgnoredIfValuesAreProvided(t *testing.T) {
 	type D struct {
-		S string  `schema:"s" default:"test1"`
-		I int     `schema:"i" default:"21"`
-		B bool    `schema:"b" default:"false"`
-		F float64 `schema:"f" default:"3.14"`
-		U uint    `schema:"u" default:"1"`
+		S string  `schema:"s,default:test1"`
+		I int     `schema:"i,default:21"`
+		B bool    `schema:"b,default:false"`
+		F float64 `schema:"f,default:3.14"`
+		U uint    `schema:"u,default:1"`
 	}
 
 	data := map[string][]string{"s": {"s"}, "i": {"1"}, "b": {"true"}, "f": {"0.22"}, "u": {"14"}}
@@ -2163,11 +2161,11 @@ func TestDefaultValuesAreIgnoredIfValuesAreProvided(t *testing.T) {
 func TestRequiredFieldsCannotHaveDefaults(t *testing.T) {
 
 	type D struct {
-		S string  `schema:"s,required" default:"test1"`
-		I int     `schema:"i,required" default:"21"`
-		B bool    `schema:"b,required" default:"false"`
-		F float64 `schema:"f,required" default:"3.14"`
-		U uint    `schema:"u,required" default:"1"`
+		S string  `schema:"s,required,default:test1"`
+		I int     `schema:"i,required,default:21"`
+		B bool    `schema:"b,required,default:false"`
+		F float64 `schema:"f,required,default:3.14"`
+		U uint    `schema:"u,required,default:1"`
 	}
 
 	data := map[string][]string{"s": {"s"}, "i": {"1"}, "b": {"true"}, "f": {"0.22"}, "u": {"14"}}
@@ -2189,8 +2187,8 @@ func TestRequiredFieldsCannotHaveDefaults(t *testing.T) {
 func TestDefaultsAreNotSupportedForStructsAndSlices(t *testing.T) {
 
 	type D struct {
-		S S1       `schema:"s" default:"{f1:0}"`
-		A []string `schema:"s" default:"test1,test2"`
+		S S1       `schema:"s,default:{f1:0}"`
+		A []string `schema:"s,default:test1,test2"`
 	}
 
 	d := D{}
@@ -2201,10 +2199,9 @@ func TestDefaultsAreNotSupportedForStructsAndSlices(t *testing.T) {
 
 	err := decoder.Decode(&d, data)
 
-	expected := "default tag is supported only on: bool, float variants, string, unit variants types or their corresponding pointers"
+	expected := "default option is supported only on: bool, float variants, string, unit variants types or their corresponding pointers"
 
 	if err == nil || !strings.Contains(err.Error(), expected) {
 		t.Errorf("decoding should fail with error msg %s got %q", expected, err)
 	}
-
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2057,7 +2057,6 @@ func TestUnmashalPointerToEmbedded(t *testing.T) {
 }
 
 func TestDefaultValuesAreSet(t *testing.T) {
-
 	type N struct {
 		S1 string    `schema:"s1,default:test1"`
 		I2 int       `schema:"i2,default:22"`
@@ -2068,9 +2067,18 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		N
 		S string   `schema:"s,default:test1"`
 		I int      `schema:"i,default:21"`
+		J int8     `schema:"j,default:2"`
+		K int16    `schema:"k,default:-455"`
+		L int32    `schema:"l,default:899"`
+		M int64    `schema:"m,default:12455"`
 		B bool     `schema:"b,default:false"`
 		F float64  `schema:"f,default:3.14"`
+		G float32  `schema:"g,default:19.12"`
 		U uint     `schema:"u,default:1"`
+		V uint8    `schema:"v,default:190"`
+		W uint16   `schema:"w,default:20000"`
+		Y uint32   `schema:"y,default:156666666"`
+		Z uint64   `schema:"z,default:1545465465465546"`
 		X []string `schema:"x,default:x1|x2"`
 	}
 
@@ -2092,9 +2100,18 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		},
 		S: "test1",
 		I: 21,
+		J: 2,
+		K: -455,
+		L: 899,
+		M: 12455,
 		B: false,
 		F: 3.14,
+		G: 19.12,
 		U: 1,
+		V: 190,
+		W: 20000,
+		Y: 156666666,
+		Z: 1545465465465546,
 		X: []string{"x1", "x2"},
 	}
 
@@ -2106,9 +2123,18 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		*N
 		S *string  `schema:"s,default:test1"`
 		I *int     `schema:"i,default:21"`
+		J *int8    `schema:"j,default:2"`
+		K *int16   `schema:"k,default:-455"`
+		L *int32   `schema:"l,default:899"`
+		M *int64   `schema:"m,default:12455"`
 		B *bool    `schema:"b,default:false"`
 		F *float64 `schema:"f,default:3.14"`
+		G *float32 `schema:"g,default:19.12"`
 		U *uint    `schema:"u,default:1"`
+		V *uint8   `schema:"v,default:190"`
+		W *uint16  `schema:"w,default:20000"`
+		Y *uint32  `schema:"y,default:156666666"`
+		Z *uint64  `schema:"z,default:1545465465465546"`
 		X []string `schema:"x,default:x1|x2"`
 	}
 
@@ -2164,7 +2190,6 @@ func TestDefaultValuesAreIgnoredIfValuesAreProvided(t *testing.T) {
 }
 
 func TestRequiredFieldsCannotHaveDefaults(t *testing.T) {
-
 	type D struct {
 		S string  `schema:"s,required,default:test1"`
 		I int     `schema:"i,required,default:21"`
@@ -2190,12 +2215,38 @@ func TestRequiredFieldsCannotHaveDefaults(t *testing.T) {
 }
 
 func TestInvalidDefaultsValuesHaveNoEffect(t *testing.T) {
-
 	type D struct {
 		A []int    `schema:"a,default:wrong1|wrong2"`
 		B bool     `schema:"b,default:invalid"`
 		C *float32 `schema:"c,default:notAFloat"`
-		D uint8    `schema:"d,default:8000000"`
+		//uint types
+		D uint   `schema:"d,default:notUint"`
+		E uint8  `schema:"e,default:notUint"`
+		F uint16 `schema:"f,default:notUint"`
+		G uint32 `schema:"g,default:notUint"`
+		H uint64 `schema:"h,default:notUint"`
+		// uint types pointers
+		I *uint   `schema:"i,default:notUint"`
+		J *uint8  `schema:"j,default:notUint"`
+		K *uint16 `schema:"k,default:notUint"`
+		L *uint32 `schema:"l,default:notUint"`
+		M *uint64 `schema:"m,default:notUint"`
+		// int types
+		N int   `schema:"n,default:notInt"`
+		O int8  `schema:"o,default:notInt"`
+		P int16 `schema:"p,default:notInt"`
+		Q int32 `schema:"q,default:notInt"`
+		R int64 `schema:"r,default:notInt"`
+		// int types pointers
+		S *int   `schema:"s,default:notInt"`
+		T *int8  `schema:"t,default:notInt"`
+		U *int16 `schema:"u,default:notInt"`
+		V *int32 `schema:"v,default:notInt"`
+		W *int64 `schema:"w,default:notInt"`
+		// float
+		X float32  `schema:"c,default:notAFloat"`
+		Y float64  `schema:"c,default:notAFloat"`
+		Z *float64 `schema:"c,default:notAFloat"`
 	}
 
 	d := D{}
@@ -2218,7 +2269,6 @@ func TestInvalidDefaultsValuesHaveNoEffect(t *testing.T) {
 }
 
 func TestDefaultsAreNotSupportedForStructsAndStructSlices(t *testing.T) {
-
 	type C struct {
 		C string `schema:"c"`
 	}
@@ -2227,6 +2277,7 @@ func TestDefaultsAreNotSupportedForStructsAndStructSlices(t *testing.T) {
 		S S1     `schema:"s,default:{f1:0}"`
 		A []C    `schema:"a,default:{c:test1}|{c:test2}"`
 		B []*int `schema:"b,default:12"`
+		E *C     `schema:"e,default:{c:test3}"`
 	}
 
 	d := D{}


### PR DESCRIPTION
**Summary of Changes**

this is the implementation for the functionality described in #182 

1. add support for an optional `default` tag to allow setting values when decoding in case no value is provided 
2. limiting the `default` tag scope to only primitive types and their pointers as well
