### PR TITLE
add option to prevent encoding of unmatched tags

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -152,7 +152,7 @@ func (c *cache) create(t reflect.Type, parentAlias string) *structInfo {
 
 // createField creates a fieldInfo for the given field.
 func (c *cache) createField(field reflect.StructField, parentAlias string) *fieldInfo {
-	alias, options := fieldAlias(field, c.tag)
+	alias, options, _ := fieldAlias(field, c.tag)
 	if alias == "-" {
 		// Ignore this field.
 		return nil
@@ -273,14 +273,15 @@ func indirectType(typ reflect.Type) reflect.Type {
 }
 
 // fieldAlias parses a field tag to get a field alias.
-func fieldAlias(field reflect.StructField, tagName string) (alias string, options tagOptions) {
+func fieldAlias(field reflect.StructField, tagName string) (alias string, options tagOptions, tagMatched bool) {
 	if tag := field.Tag.Get(tagName); tag != "" {
 		alias, options = parseTag(tag)
+		tagMatched = true
 	}
 	if alias == "" {
 		alias = field.Name
 	}
-	return alias, options
+	return alias, options, tagMatched
 }
 
 // tagOptions is the string following a comma in a struct field's tag, or

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -511,3 +511,30 @@ func TestRegisterEncoderWithPtrType(t *testing.T) {
 	valExists(t, "DateStart", ss.DateStart.time.String(), vals)
 	valExists(t, "DateEnd", "", vals)
 }
+
+func TestEncoderIgnoreUnmatchedTag(t *testing.T) {
+	type S1 struct {
+		SomeJSON  string `json:"some_json"`
+		SomeQuery string `query:"some_query"`
+		SomeEmpty string
+	}
+
+	data := map[string][]string{}
+
+	s := S1{
+		SomeJSON:  "some-json",
+		SomeQuery: "some-query",
+		SomeEmpty: "some-empty",
+	}
+
+	encoder := NewEncoder()
+	encoder.SetAliasTag("json")
+	encoder.IgnoreUnmatchedTag(true)
+
+	err := encoder.Encode(&s, data)
+
+	noError(t, err)
+	valExists(t, "some_json", "some-json", data)
+	valNotExists(t, "SomeQuery", data)
+	valNotExists(t, "SomeEmpty", data)
+}


### PR DESCRIPTION
Hi Guys,

Initially thanks for the creating of this useful package, it saves a day!
I'm using this package in production and it works well actually. 

In some cases, I need to prevent the encoding of unmatched tags. Then, I decided to add this into the package as an option like `ignoreUnknwonKeys` field with tests of course. 

Here's an example case: 

I want to generate a full request object from one struct like:

```go
struct A {
     HeaderField1 string `header:"header1"`
     QueryField1 string `query:"query1"`
}
```

For Header, I need to get the `header` tag only, for query params I need to get the `query` tag only. In the current implementation, I could not find a way to do it. 

**Summary of Changes**

1.  add an option to prevent encoding of unmatched tags


Thanks,
Furkan.