### PR TITLE
enable to decode with case sensitive tags

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -188,6 +188,8 @@ func (c *cache) createField(field reflect.StructField, parentAlias string) *fiel
 		}
 	}
 
+	_, hasTag := field.Tag.Lookup(c.tag)
+
 	return &fieldInfo{
 		typ:              field.Type,
 		name:             field.Name,
@@ -197,6 +199,7 @@ func (c *cache) createField(field reflect.StructField, parentAlias string) *fiel
 		isSliceOfStructs: isSlice && isStruct,
 		isAnonymous:      field.Anonymous,
 		isRequired:       options.Contains("required"),
+		hasTag:           hasTag,
 	}
 }
 
@@ -213,7 +216,8 @@ type structInfo struct {
 
 func (i *structInfo) get(alias string) *fieldInfo {
 	for _, field := range i.fields {
-		if strings.EqualFold(field.alias, alias) {
+		if !field.hasTag && strings.EqualFold(field.alias, alias) ||
+			field.hasTag && field.alias == alias {
 			return field
 		}
 	}
@@ -248,6 +252,7 @@ type fieldInfo struct {
 	// isAnonymous indicates whether the field is embedded in the struct.
 	isAnonymous bool
 	isRequired  bool
+	hasTag      bool
 }
 
 func (f *fieldInfo) paths(prefix string) []string {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2024,3 +2024,27 @@ func TestUnmashalPointerToEmbedded(t *testing.T) {
 		t.Errorf("Expected %v errors, got %v", expected, s.Value)
 	}
 }
+
+func TestCaseSensitive(t *testing.T) {
+	data := map[string][]string{
+		"x": {"a"},
+		"X": {"b"},
+	}
+
+	decoder := NewDecoder()
+
+	var cnt int
+	for i := 0; i < 1000; i++ {
+		var v struct {
+			X string `schema:"x"`
+		}
+		_ = decoder.Decode(&v, data)
+		if v.X != "a" {
+			cnt++
+		}
+	}
+
+	if cnt > 0 {
+		t.Errorf("Expected %v errors, got %v", 0, cnt)
+	}
+}


### PR DESCRIPTION
Fixes #188 

**Summary of Changes**

1. Add `fieldInfo` to `hasTag` field.
2. In case `hasTag` is `true`, compare `field.alias` and `alias` case sensitively in structInfo.get method.
3. Add testing for this change.