### PR TITLE
Encode: fix panic with unsupported Kind pointer

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -165,6 +165,9 @@ func typeEncoder(t reflect.Type, reg map[reflect.Type]encoderFunc) encoderFunc {
 		return encodeFloat64
 	case reflect.Ptr:
 		f := typeEncoder(t.Elem(), reg)
+		if f == nil {
+			return nil
+		}
 		return func(v reflect.Value) string {
 			if v.IsNil() {
 				return "null"

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -408,6 +408,22 @@ func TestStructPointer(t *testing.T) {
 	valNotExists(t, "F03", vals)
 }
 
+type E7 struct {
+	F01 *complex128
+}
+
+func TestUnsupportedKindPointer(t *testing.T) {
+	vals := map[string][]string{}
+	f01 := complex(1, 2)
+	s := E7{
+		F01: &f01,
+	}
+
+	encoder := NewEncoder()
+	encoder.Encode(&s, vals)
+	valNotExists(t, "F01", vals)
+}
+
 func TestRegisterEncoderCustomArrayType(t *testing.T) {
 	type CustomInt []int
 	type S1 struct {


### PR DESCRIPTION
Fixes #164

**Summary of Changes**

1. Encode fails with panic, if input value has a pointer of unsupported Kind.
2. I fixed this by ignoring pointers of unsupported Kinds.
