### PR TITLE
fixed panic: reflect: indirection through nil pointer to embedded struct

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -117,7 +117,7 @@ func (c *cache) get(t reflect.Type) *structInfo {
 	info := c.m[t]
 	c.l.RUnlock()
 	if info == nil {
-		info = c.create(t, "")
+		info = c.create(t, "", nil)
 		c.l.Lock()
 		c.m[t] = info
 		c.l.Unlock()
@@ -126,14 +126,14 @@ func (c *cache) get(t reflect.Type) *structInfo {
 }
 
 // create creates a structInfo with meta-data about a struct.
-func (c *cache) create(t reflect.Type, parentAlias string) *structInfo {
+func (c *cache) create(t reflect.Type, parentAlias string, fieldIndex []int) *structInfo {
 	info := &structInfo{}
 	var anonymousInfos []*structInfo
 	for i := 0; i < t.NumField(); i++ {
-		if f := c.createField(t.Field(i), parentAlias); f != nil {
+		if f := c.createField(t.Field(i), parentAlias, fieldIndex); f != nil {
 			info.fields = append(info.fields, f)
 			if ft := indirectType(f.typ); ft.Kind() == reflect.Struct && f.isAnonymous {
-				anonymousInfos = append(anonymousInfos, c.create(ft, f.canonicalAlias))
+				anonymousInfos = append(anonymousInfos, c.create(ft, f.canonicalAlias, append(fieldIndex, t.Field(i).Index...)) )
 			}
 		}
 	}
@@ -151,7 +151,7 @@ func (c *cache) create(t reflect.Type, parentAlias string) *structInfo {
 }
 
 // createField creates a fieldInfo for the given field.
-func (c *cache) createField(field reflect.StructField, parentAlias string) *fieldInfo {
+func (c *cache) createField(field reflect.StructField, parentAlias string, parentIndex []int) *fieldInfo {
 	alias, options := fieldAlias(field, c.tag)
 	if alias == "-" {
 		// Ignore this field.
@@ -198,6 +198,7 @@ func (c *cache) createField(field reflect.StructField, parentAlias string) *fiel
 		isAnonymous:      field.Anonymous,
 		isRequired:       options.Contains("required"),
 		defaultValue:     options.getDefaultOptionValue(),
+		fieldIndex:       append(parentIndex, field.Index...),
 	}
 }
 
@@ -250,6 +251,8 @@ type fieldInfo struct {
 	isAnonymous  bool
 	isRequired   bool
 	defaultValue string
+
+	fieldIndex []int
 }
 
 func (f *fieldInfo) paths(prefix string) []string {

--- a/decoder.go
+++ b/decoder.go
@@ -105,7 +105,10 @@ func (d *Decoder) setDefaults(t reflect.Type, v reflect.Value) MultiError {
 	errs := MultiError{}
 
 	for _, f := range struc.fields {
-		vCurrent := v.FieldByName(f.name)
+		vCurrent, err := v.FieldByIndexErr(f.fieldIndex)
+		if err != nil {
+			continue
+		}
 
 		if vCurrent.Type().Kind() == reflect.Struct && f.defaultValue == "" {
 			errs.merge(d.setDefaults(vCurrent.Type(), vCurrent))

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2056,6 +2056,74 @@ func TestUnmashalPointerToEmbedded(t *testing.T) {
 	}
 }
 
+type S24 struct {
+	F1 string `schema:"F1"`
+}
+
+type S24e struct {
+	*S24
+	F2 string `schema:"F2"`	
+}
+
+func TestUnmarshallToEmbeddedNoData(t *testing.T) {
+	data := map[string][]string{
+		"F3": {"raw a"},
+	}
+
+	s := &S24e{}
+
+	decoder := NewDecoder()
+	err := decoder.Decode(s, data);
+	
+	expectedErr := `schema: invalid path "F3"`
+	if err.Error() != expectedErr {
+		t.Fatalf("got %q, want %q", err, expectedErr)
+	}
+}
+type S25ee struct {
+	F3 string `schema:"F3"`
+}
+
+type S25e struct {
+	S25ee
+	F2 string `schema:"F2"`
+}
+
+type S25 struct {
+	S25e
+	F1 string `schema:"F1"`
+}
+
+func TestDoubleEmbedded(t *testing.T){
+	data := map[string][]string{
+		"F1": {"raw a"},
+		"F2": {"raw b"},
+		"F3": {"raw c"},
+	}
+
+	
+	s := S25{}
+	decoder := NewDecoder()
+
+	if err := decoder.Decode(&s, data); err != nil {
+		t.Fatal("Error while decoding:", err)
+	}
+
+	expected := S25{
+		F1: "raw a",
+		S25e: S25e{
+			F2: "raw b",
+			S25ee: S25ee{
+				F3: "raw c",
+			},
+		},
+	}
+	if !reflect.DeepEqual(expected, s) {
+		t.Errorf("Expected %v errors, got %v", expected, s)
+	}
+
+}
+
 func TestDefaultValuesAreSet(t *testing.T) {
 	type N struct {
 		S1 string    `schema:"s1,default:test1"`


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

The provided test `TestUnmarshallToEmbeddedNoData` shows that the decoder panics when `setDefaults` encounters a nil pointer to an embedded struct. The fix replaces `FieldByName` with `FieldByIndexErr` to catch this kind of situation and continue with the next field.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
