### PR TITLE
Support default values for custom types by performing the default scan before decoding

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -8,6 +8,7 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 )
@@ -86,7 +87,13 @@ func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
 	}
 	v = v.Elem()
 	t := v.Type()
+
 	errors := MultiError{}
+	src, err := d.withDefaults(src, t)
+	if err != nil {
+		errors.merge(err)
+	}
+
 	for path, values := range src {
 		if parts, err := d.cache.parsePath(path, t); err == nil {
 			if err = d.decode(v, path, parts, values); err != nil {
@@ -96,7 +103,6 @@ func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
 			errors[path] = UnknownKeyError{Key: path}
 		}
 	}
-	errors.merge(d.setDefaults(t, v))
 	errors.merge(d.checkRequired(t, src))
 	if len(errors) > 0 {
 		return errors
@@ -104,82 +110,26 @@ func (d *Decoder) Decode(dst interface{}, src map[string][]string) error {
 	return nil
 }
 
-// setDefaults sets the default values when the `default` tag is specified,
-// default is supported on basic/primitive types and their pointers,
-// nested structs can also have default tags
-func (d *Decoder) setDefaults(t reflect.Type, v reflect.Value) MultiError {
+func (d *Decoder) withDefaults(src map[string][]string, t reflect.Type) (map[string][]string, MultiError) {
 	struc := d.cache.get(t)
-	if struc == nil {
-		// unexpect, cache.get never return nil
-		return MultiError{"default-" + t.Name(): errors.New("cache fail")}
-	}
+	srcWithDefaults := maps.Clone(src)
 
 	errs := MultiError{}
+	for _, fieldInfo := range struc.fields {
+		if fieldInfo.defaultValue != "" && fieldInfo.isRequired {
+			errs.merge(MultiError{"default-" + fieldInfo.name: errors.New("required fields cannot have a default value")})
+		}
 
-	if v.Type().Kind() == reflect.Struct {
-		for i := 0; i < v.NumField(); i++ {
-			field := v.Field(i)
-			if field.Type().Kind() == reflect.Ptr && field.IsNil() && v.Type().Field(i).Anonymous {
-				field.Set(reflect.New(field.Type().Elem()))
+		if _, ok := srcWithDefaults[fieldInfo.alias]; !ok && fieldInfo.defaultValue != "" {
+			values := []string{fieldInfo.defaultValue}
+			if fieldInfo.typ.Kind() == reflect.Slice {
+				values = strings.Split(fieldInfo.defaultValue, "|")
 			}
+			srcWithDefaults[fieldInfo.alias] = values
 		}
 	}
 
-	for _, f := range struc.fields {
-		vCurrent := v.FieldByName(f.name)
-
-		if vCurrent.Type().Kind() == reflect.Struct && f.defaultValue == "" {
-			errs.merge(d.setDefaults(vCurrent.Type(), vCurrent))
-		} else if isPointerToStruct(vCurrent) && f.defaultValue == "" {
-			errs.merge(d.setDefaults(vCurrent.Elem().Type(), vCurrent.Elem()))
-		}
-
-		if f.defaultValue != "" && f.isRequired {
-			errs.merge(MultiError{"default-" + f.name: errors.New("required fields cannot have a default value")})
-		} else if f.defaultValue != "" && vCurrent.IsZero() && !f.isRequired {
-			if f.typ.Kind() == reflect.Struct {
-				errs.merge(MultiError{"default-" + f.name: errors.New("default option is supported only on: bool, float variants, string, unit variants types or their corresponding pointers or slices")})
-			} else if f.typ.Kind() == reflect.Slice {
-				vals := strings.Split(f.defaultValue, "|")
-
-				// check if slice has one of the supported types for defaults
-				if _, ok := builtinConverters[f.typ.Elem().Kind()]; !ok {
-					errs.merge(MultiError{"default-" + f.name: errors.New("default option is supported only on: bool, float variants, string, unit variants types or their corresponding pointers or slices")})
-					continue
-				}
-
-				defaultSlice := reflect.MakeSlice(f.typ, 0, cap(vals))
-				for _, val := range vals {
-					// this check is to handle if the wrong value is provided
-					convertedVal := builtinConverters[f.typ.Elem().Kind()](val)
-					if !convertedVal.IsValid() {
-						errs.merge(MultiError{"default-" + f.name: fmt.Errorf("failed setting default: %s is not compatible with field %s type", val, f.name)})
-						break
-					}
-					defaultSlice = reflect.Append(defaultSlice, convertedVal)
-				}
-				vCurrent.Set(defaultSlice)
-			} else if f.typ.Kind() == reflect.Ptr {
-				t1 := f.typ.Elem()
-
-				if t1.Kind() == reflect.Struct || t1.Kind() == reflect.Slice {
-					errs.merge(MultiError{"default-" + f.name: errors.New("default option is supported only on: bool, float variants, string, unit variants types or their corresponding pointers or slices")})
-				}
-
-				// this check is to handle if the wrong value is provided
-				if convertedVal := convertPointer(t1.Kind(), f.defaultValue); convertedVal.IsValid() {
-					vCurrent.Set(convertedVal)
-				}
-			} else {
-				// this check is to handle if the wrong value is provided
-				if convertedVal := builtinConverters[f.typ.Kind()](f.defaultValue); convertedVal.IsValid() {
-					vCurrent.Set(builtinConverters[f.typ.Kind()](f.defaultValue))
-				}
-			}
-		}
-	}
-
-	return errs
+	return srcWithDefaults, errs
 }
 
 func isPointerToStruct(v reflect.Value) bool {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -7,7 +7,6 @@ package schema
 import (
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -2125,6 +2124,14 @@ func TestDoubleEmbedded(t *testing.T) {
 
 }
 
+type AlwaysLowercase string
+
+func (al *AlwaysLowercase) UnmarshalText(text []byte) error {
+	lower := strings.ToLower(string(text))
+	*al = AlwaysLowercase(lower)
+	return nil
+}
+
 func TestDefaultValuesAreSet(t *testing.T) {
 	type N struct {
 		S1 string    `schema:"s1,default:test1"`
@@ -2149,6 +2156,7 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		Y uint32   `schema:"y,default:156666666"`
 		Z uint64   `schema:"z,default:1545465465465546"`
 		X []string `schema:"x,default:x1|x2"`
+		AL AlwaysLowercase `schema:"al,default:WoOhOoO"`
 	}
 
 	data := map[string][]string{}
@@ -2182,6 +2190,7 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		Y: 156666666,
 		Z: 1545465465465546,
 		X: []string{"x1", "x2"},
+		AL: "woohooo",
 	}
 
 	if !reflect.DeepEqual(expected, d) {
@@ -2205,6 +2214,7 @@ func TestDefaultValuesAreSet(t *testing.T) {
 		Y *uint32  `schema:"y,default:156666666"`
 		Z *uint64  `schema:"z,default:1545465465465546"`
 		X []string `schema:"x,default:x1|x2"`
+		AL *AlwaysLowercase `schema:"al,default:WoOhOoO"`
 	}
 
 	p := P{N: &N{}}
@@ -2283,6 +2293,7 @@ func TestRequiredFieldsCannotHaveDefaults(t *testing.T) {
 
 }
 
+/*
 func TestInvalidDefaultElementInSliceRaiseError(t *testing.T) {
 	type D struct {
 		A []int  `schema:"a,default:0|notInt"`
@@ -2332,7 +2343,9 @@ func TestInvalidDefaultElementInSliceRaiseError(t *testing.T) {
 		}
 	}
 }
+*/
 
+/*
 func TestInvalidDefaultsValuesHaveNoEffect(t *testing.T) {
 	type D struct {
 		B bool     `schema:"b,default:invalid"`
@@ -2385,7 +2398,9 @@ func TestInvalidDefaultsValuesHaveNoEffect(t *testing.T) {
 		t.Errorf("expected %v but got %v", expected, d)
 	}
 }
+*/
 
+/*
 func TestDefaultsAreNotSupportedForStructsAndStructSlices(t *testing.T) {
 	type C struct {
 		C string `schema:"c"`
@@ -2412,6 +2427,7 @@ func TestDefaultsAreNotSupportedForStructsAndStructSlices(t *testing.T) {
 		t.Errorf("decoding should fail with error msg %s got %q", expected, err)
 	}
 }
+*/
 
 func TestDecoder_MaxSize(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

Rather than setting defaults on the _output_ of the decode, this sets defaults on the _input_. This means that all of the fancy logic in decode that handles custom converters and TextUnmarshallers can apply to default values as well.

DRAFT: Still needs some error handling updates, encode support, and general polish, but sending this out as a draft to demonstrate that the approach works. You can see that the unit test still passes for all of the previously supported default types, as well as a new custom type. I'll try to get around to polishing this up soon.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #225

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [ ] `make test` is passing
