### PR TITLE
Add option to encode value keys with '.' separators

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -45,8 +45,8 @@ func (e *Encoder) SetAliasTag(tag string) {
 // name consisting of each field name in its path separated with a period.
 //
 // Allows from nested struct encoded values to be decoded again using schema.Decode.
-func (e *Encoder) KeyOriginalPath(originalKeyPath bool) {
-	e.keyOriginalPath = originalKeyPath
+func (e *Encoder) KeyOriginalPath(keyOriginalPath bool) {
+	e.keyOriginalPath = keyOriginalPath
 }
 
 // isValidStructPointer test if input value is a valid struct pointer.

--- a/encoder.go
+++ b/encoder.go
@@ -11,9 +11,9 @@ type encoderFunc func(reflect.Value) string
 
 // Encoder encodes values from a struct into url.Values.
 type Encoder struct {
-	cache         *cache
-	regenc        map[reflect.Type]encoderFunc
-	keySeparation bool
+	cache           *cache
+	regenc          map[reflect.Type]encoderFunc
+	keyOriginalPath bool
 }
 
 // NewEncoder returns a new Encoder with defaults.
@@ -41,12 +41,12 @@ func (e *Encoder) SetAliasTag(tag string) {
 	e.cache.tag = tag
 }
 
-// ActivateKeySeparation causes the keys of nested struct fields to be separated
-// with a period when encoding.
+// KeyOriginalPath causes the keys of nested struct fields to keep their full original
+// name consisting of each field name in its path separated with a period.
 //
-// Allows encoded values to be decoded again using schema.Decode.
-func (e *Encoder) ActivateKeySeparation() {
-	e.keySeparation = true
+// Allows from nested struct encoded values to be decoded again using schema.Decode.
+func (e *Encoder) KeyOriginalPath(originalKeyPath bool) {
+	e.keyOriginalPath = originalKeyPath
 }
 
 // isValidStructPointer test if input value is a valid struct pointer.
@@ -100,7 +100,7 @@ func (e *Encoder) encode(v reflect.Value, dst map[string][]string, prefix string
 		if name == "-" {
 			continue
 		}
-		if prefix != "" && e.keySeparation {
+		if prefix != "" && e.keyOriginalPath {
 			name = prefix + "." + name
 		}
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -524,7 +524,7 @@ func TestRegisterEncoderWithPtrType(t *testing.T) {
 	valExists(t, "DateEnd", "", vals)
 }
 
-func TestEncoder_WithOriginalKeyPath(t *testing.T) {
+func TestEncoderKeyOriginalPath(t *testing.T) {
 	type outter struct {
 		Inner inner
 	}
@@ -541,7 +541,7 @@ func TestEncoder_WithOriginalKeyPath(t *testing.T) {
 	}
 
 	encoder := NewEncoder()
-	encoder.OriginalKeyPath(true)
+	encoder.KeyOriginalPath(true)
 
 	vals := map[string][]string{}
 	err := encoder.Encode(nest, vals)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -524,7 +524,7 @@ func TestRegisterEncoderWithPtrType(t *testing.T) {
 	valExists(t, "DateEnd", "", vals)
 }
 
-func TestSeparation(t *testing.T) {
+func TestEncoder_WithOriginalKeyPath(t *testing.T) {
 	type outter struct {
 		Inner inner
 	}
@@ -541,7 +541,7 @@ func TestSeparation(t *testing.T) {
 	}
 
 	encoder := NewEncoder()
-	encoder.ActivateKeySeparation()
+	encoder.OriginalKeyPath(true)
 
 	vals := map[string][]string{}
 	err := encoder.Encode(nest, vals)

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -526,7 +526,8 @@ func TestRegisterEncoderWithPtrType(t *testing.T) {
 
 func TestEncoderKeyOriginalPath(t *testing.T) {
 	type outter struct {
-		Inner inner
+		Inner    inner
+		InnerPtr *inner
 	}
 	type nested struct {
 		Outter outter
@@ -535,6 +536,9 @@ func TestEncoderKeyOriginalPath(t *testing.T) {
 	nest := nested{
 		Outter: outter{
 			Inner: inner{
+				F12: 12,
+			},
+			InnerPtr: &inner{
 				F12: 12,
 			},
 		},
@@ -549,6 +553,7 @@ func TestEncoderKeyOriginalPath(t *testing.T) {
 	t.Log(vals)
 
 	noError(t, err)
-	valsLength(t, 1, vals)
+	valsLength(t, 2, vals)
 	valExists(t, "Outter.Inner.F12", "12", vals)
+	valExists(t, "Outter.InnerPtr.F12", "12", vals)
 }

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -523,3 +523,32 @@ func TestRegisterEncoderWithPtrType(t *testing.T) {
 	valExists(t, "DateStart", ss.DateStart.time.String(), vals)
 	valExists(t, "DateEnd", "", vals)
 }
+
+func TestSeparation(t *testing.T) {
+	type outter struct {
+		Inner inner
+	}
+	type nested struct {
+		Outter outter
+	}
+
+	nest := nested{
+		Outter: outter{
+			Inner: inner{
+				F12: 12,
+			},
+		},
+	}
+
+	encoder := NewEncoder()
+	encoder.ActivateKeySeparation()
+
+	vals := map[string][]string{}
+	err := encoder.Encode(nest, vals)
+
+	t.Log(vals)
+
+	noError(t, err)
+	valsLength(t, 1, vals)
+	valExists(t, "Outter.Inner.F12", "12", vals)
+}


### PR DESCRIPTION
## Description

The `Encoder` struct has now a method called `ActivateKeySeparation`.
When this option is activated the keys of the `values map[string][]string`
will be the full path containing all names of the nested struct fields separated
by a period (`.`).

This also fixes the bug referenced in #228 that it is currently not possible to
decode values into structs with nested fields after encoding said structs.

**I'm not sure about the naming so I'm open for suggestions if someone has better ideas.**

## Example

```go
f := Foo{
    X: "hello",
    Y: Bar{
        A: "world",
        B: true,
    },
}

vals := map[string][]string{}
encoder := schema.NewEncoder()
encoder.ActivateKeySeparation()

encoder.Encode(f, vals)
fmt.Println(vals) // output: map[y.a:[test] y.b:[true] x:[test]]
```

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #228 
- Closes #228 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing
