### PR TITLE
Update decoder to not panic when there are unexported fields in a different package.

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -127,6 +127,9 @@ func (d *Decoder) setDefaults(t reflect.Type, v reflect.Value) MultiError {
 
 	for _, f := range struc.fields {
 		vCurrent := v.FieldByName(f.name)
+		if !vCurrent.CanSet() {
+			continue
+		}
 
 		if vCurrent.Type().Kind() == reflect.Struct && f.defaultValue == "" {
 			errs.merge(d.setDefaults(vCurrent.Type(), vCurrent))


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
Fix a bug to make this backward compatible with v1.2.1

## Related Tickets & Documents
https://github.com/gorilla/schema/issues/234

- Related Issue #234
- Closes #234 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: small change
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing (failing the same like it fails for `main` branch)
- [x] `make test` is passing
