### PR TITLE
Optimization for `cache.parsePath` to reduce allocations

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,7 +7,6 @@ package schema
 import (
 	"errors"
 	"reflect"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,25 +37,35 @@ func (c *cache) registerConverter(value interface{}, converterFunc Converter) {
 	c.regconv[reflect.TypeOf(value)] = converterFunc
 }
 
+// pathIter is used to iterate over the dotted notation argument to (*cache).parsePath.
+// internally it utilizes strings.Cut to minimize allocations and garbage generated.
+//
+// this should be used with a for loop as:
+//
+//	var it pathIter
+//	for key, ok := it.start(path); ok; key, ok = it.advance() {}
 type pathIter struct {
 	rest string
 }
 
+// start initializes the iteration, and returns the first key.
 func (p *pathIter) start(path string) (string, bool) {
 	return p.next(path)
 }
 
+// advance advances the iteration to the next key.
 func (p *pathIter) advance() (string, bool) {
 	return p.next(p.rest)
 }
 
-func (p *pathIter) next(path string) (key string, found bool) {
-	key, p.rest, found = strings.Cut(path, ".")
-	// special case for paths without ".". this can be the beginning or end of a path.
-	if !found && key != "" {
-		return key, true
-	}
-	return key, found
+// next should only be used by (*pathIter).start and (*pathIter).advance. it will cut path,
+// and return the "before", storing the "after" for the subsequent call.
+// if path does not contain "." and is non-empty, it will return (path, true), storing "".
+// if path is empty, it will return ("", false). this means the end of iteration.
+func (p *pathIter) next(path string) (key string, ok bool) {
+	key, p.rest, _ = strings.Cut(path, ".")
+	ok = key != ""
+	return key, ok
 }
 
 // parsePath parses a path in dotted notation verifying that it is a valid
@@ -74,13 +83,13 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 	// path will be appended to every valid element of the path, but parts will
 	// only be appended to for each slice of struct.
 	n := strings.Count(p, ".")
-	if n == 0 {
+	if n == 0 { // note: go1.21 max()
 		n = 1
 	}
 	parts := make([]pathPart, 0, n)
 	path := make([]string, 0, n)
 	var it pathIter
-	for key, found := it.start(p); found; key, found = it.advance() {
+	for key, ok := it.start(p); ok; key, ok = it.advance() {
 		if t.Kind() != reflect.Struct {
 			return nil, errInvalidPath
 		}
@@ -99,15 +108,15 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 			// Now that struct can implements TextUnmarshaler interface,
 			// we don't need to force the struct's fields to appear in the path.
 			// So checking i+2 is not necessary anymore.
-			key, found = it.advance()
-			if !found {
+			key, ok = it.advance()
+			if !ok {
 				return nil, errInvalidPath
 			}
 			if index64, err = strconv.ParseInt(key, 10, 0); err != nil {
 				return nil, errInvalidPath
 			}
 			parts = append(parts, pathPart{
-				path:  slices.Clip(path),
+				path:  path[:len(path):len(path)], // note: go1.21 slices.Clip()
 				field: field,
 				index: int(index64),
 			})
@@ -133,11 +142,11 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 	}
 	// Add the remaining.
 	parts = append(parts, pathPart{
-		path:  slices.Clip(path),
+		path:  path[:len(path):len(path)], // note: go1.21 slices.Clip()
 		field: field,
 		index: -1,
 	})
-	parts = slices.Clip(parts)
+	parts = parts[:len(parts):len(parts)] // note: go1.21 slices.Clip()
 	return parts, nil
 }
 

--- a/cache.go
+++ b/cache.go
@@ -45,26 +45,32 @@ func (c *cache) registerConverter(value interface{}, converterFunc Converter) {
 //	var it pathIter
 //	for key, ok := it.start(path); ok; key, ok = it.advance() {}
 type pathIter struct {
-	rest string
+	rest      string
+	lastFound bool
 }
 
 // start initializes the iteration, and returns the first key.
 func (p *pathIter) start(path string) (string, bool) {
-	return p.next(path)
+	// init the iter for the first call to next, so that the first call will either
+	// cut on "." and return the "before", or it will return path if it does not contain
+	// ".".
+	p.rest = path
+	p.lastFound = true
+	return p.next()
 }
 
 // advance advances the iteration to the next key.
 func (p *pathIter) advance() (string, bool) {
-	return p.next(p.rest)
+	return p.next()
 }
 
-// next should only be used by (*pathIter).start and (*pathIter).advance. it will cut path,
+// next should only be used by (*pathIter).start and (*pathIter).advance. it will cut p.rest,
 // and return the "before", storing the "after" for the subsequent call.
-// if path does not contain "." and is non-empty, it will return (path, true), storing "".
-// if path is empty, it will return ("", false). this means the end of iteration.
-func (p *pathIter) next(path string) (key string, ok bool) {
-	key, p.rest, _ = strings.Cut(path, ".")
-	ok = key != ""
+func (p *pathIter) next() (key string, ok bool) {
+	var found bool
+	key, p.rest, found = strings.Cut(p.rest, ".")
+	ok = found || p.lastFound
+	p.lastFound = found
 	return key, ok
 }
 

--- a/cache.go
+++ b/cache.go
@@ -7,6 +7,7 @@ package schema
 import (
 	"errors"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,9 +49,9 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 	var field *fieldInfo
 	var index64 int64
 	var err error
-	parts := make([]pathPart, 0)
-	path := make([]string, 0)
 	keys := strings.Split(p, ".")
+	parts := make([]pathPart, 0, len(keys))
+	path := make([]string, 0, len(keys))
 	for i := 0; i < len(keys); i++ {
 		if t.Kind() != reflect.Struct {
 			return nil, errInvalidPath
@@ -78,11 +79,11 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 				return nil, errInvalidPath
 			}
 			parts = append(parts, pathPart{
-				path:  path,
+				path:  slices.Clip(path),
 				field: field,
 				index: int(index64),
 			})
-			path = make([]string, 0)
+			path = path[len(path):]
 
 			// Get the next struct type, dropping ptrs.
 			if field.typ.Kind() == reflect.Ptr {
@@ -104,10 +105,11 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 	}
 	// Add the remaining.
 	parts = append(parts, pathPart{
-		path:  path,
+		path:  slices.Clip(path),
 		field: field,
 		index: -1,
 	})
+	parts = slices.Clip(parts)
 	return parts, nil
 }
 

--- a/cache.go
+++ b/cache.go
@@ -38,6 +38,27 @@ func (c *cache) registerConverter(value interface{}, converterFunc Converter) {
 	c.regconv[reflect.TypeOf(value)] = converterFunc
 }
 
+type pathIter struct {
+	rest string
+}
+
+func (p *pathIter) start(path string) (string, bool) {
+	return p.next(path)
+}
+
+func (p *pathIter) advance() (string, bool) {
+	return p.next(p.rest)
+}
+
+func (p *pathIter) next(path string) (key string, found bool) {
+	key, p.rest, found = strings.Cut(path, ".")
+	// special case for paths without ".". this can be the beginning or end of a path.
+	if !found && key != "" {
+		return key, true
+	}
+	return key, found
+}
+
 // parsePath parses a path in dotted notation verifying that it is a valid
 // path to a struct field.
 //
@@ -49,33 +70,40 @@ func (c *cache) parsePath(p string, t reflect.Type) ([]pathPart, error) {
 	var field *fieldInfo
 	var index64 int64
 	var err error
-	keys := strings.Split(p, ".")
-	parts := make([]pathPart, 0, len(keys))
-	path := make([]string, 0, len(keys))
-	for i := 0; i < len(keys); i++ {
+	// pre-allocate parts and path using the number of ".".
+	// path will be appended to every valid element of the path, but parts will
+	// only be appended to for each slice of struct.
+	n := strings.Count(p, ".")
+	if n == 0 {
+		n = 1
+	}
+	parts := make([]pathPart, 0, n)
+	path := make([]string, 0, n)
+	var it pathIter
+	for key, found := it.start(p); found; key, found = it.advance() {
 		if t.Kind() != reflect.Struct {
 			return nil, errInvalidPath
 		}
 		if struc = c.get(t); struc == nil {
 			return nil, errInvalidPath
 		}
-		if field = struc.get(keys[i]); field == nil {
+		if field = struc.get(key); field == nil {
 			return nil, errInvalidPath
 		}
 		// Valid field. Append index.
 		path = append(path, field.name)
 		if field.isSliceOfStructs && (!field.unmarshalerInfo.IsValid || (field.unmarshalerInfo.IsValid && field.unmarshalerInfo.IsSliceElement)) {
 			// Parse a special case: slices of structs.
-			// i+1 must be the slice index.
+			// next key must be the slice index.
 			//
 			// Now that struct can implements TextUnmarshaler interface,
 			// we don't need to force the struct's fields to appear in the path.
 			// So checking i+2 is not necessary anymore.
-			i++
-			if i+1 > len(keys) {
+			key, found = it.advance()
+			if !found {
 				return nil, errInvalidPath
 			}
-			if index64, err = strconv.ParseInt(keys[i], 10, 0); err != nil {
+			if index64, err = strconv.ParseInt(key, 10, 0); err != nil {
 				return nil, errInvalidPath
 			}
 			parts = append(parts, pathPart{

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2527,3 +2527,42 @@ func TestDecoder_SetMaxSize(t *testing.T) {
 		}
 	})
 }
+
+type keyvalue struct {
+	Key   string
+	Value string
+}
+
+type sliceOfStructInput struct {
+	Attributes []keyvalue
+	Tags       []keyvalue
+}
+
+func BenchmarkSliceOfStruct(b *testing.B) {
+	d := NewDecoder()
+	v := map[string][]string{
+		"Attributes.0.Key":   {"foo0"},
+		"Attributes.0.Value": {"bar0"},
+		"Attributes.1.Key":   {"foo1"},
+		"Attributes.1.Value": {"bar1"},
+		"Attributes.2.Key":   {"foo2"},
+		"Attributes.2.Value": {"bar2"},
+		"Attributes.3.Key":   {"foo3"},
+		"Attributes.3.Value": {"bar3"},
+		"Attributes.4.Key":   {"foo4"},
+		"Attributes.4.Value": {"bar4"},
+		"Attributes.5.Key":   {"foo5"},
+		"Attributes.5.Value": {"bar5"},
+		"Tags.0.Key":         {"baz0"},
+		"Tags.0.Value":       {"bam0"},
+		"Tags.1.Key":         {"baz1"},
+		"Tags.1.Value":       {"bam1"},
+		"Tags.2.Key":         {"baz2"},
+		"Tags.2.Value":       {"bam2"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		in := &sliceOfStructInput{}
+		_ = d.Decode(in, v)
+	}
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -2566,3 +2566,29 @@ func BenchmarkSliceOfStruct(b *testing.B) {
 		_ = d.Decode(in, v)
 	}
 }
+
+func TestPathIter(t *testing.T) {
+	testcases := []string{
+		"a",
+		"a.b",
+		".b.",
+		".",
+		"..",
+		"",
+	}
+	for _, tc := range testcases {
+		t.Run(tc, func(t *testing.T) {
+			var (
+				it      pathIter
+				split   = strings.Split(tc, ".")
+				collect = make([]string, 0, len(split))
+			)
+			for k, ok := it.start(tc); ok; k, ok = it.advance() {
+				collect = append(collect, k)
+			}
+			if !reflect.DeepEqual(split, collect) {
+				t.Fatalf("expected: %q | got: %q", split, collect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

This adds preallocation of the `paths` and `parts` slices, and eliminates the usage of `strings.Split` in `(*cache).parsePath` in order to reduce the allocations. `strings.Split` is replaced with a custom iterator type that uses `strings.Cut` in order to have zero-allocations done for the iteration of the path. Despite `go1.24` introducing a similar replacement in `strings.SplitSeq`, this cannot be used because of the requirement to advance the iteration when parsing a sliceOfStruct. An `iter.Pull` iterator could also serve this purpose, but the performance would be be less improved because it allocates several objects to set up the coroutines. Regardless, either of those options would require updating the go version.

The benchmark in the package shows a speed up and allocation reduction, and a benchmark of my own workload with a lot of slice-of-struct usage shows a larger improvement. This benchmark has been added to the package.

BenchmarkAll results for `main`:
```
goos: darwin
goarch: amd64
pkg: github.com/gorilla/schema
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkAll-16    	   21609	     55065 ns/op	   18390 B/op	     379 allocs/op
PASS
ok  	github.com/gorilla/schema	2.157s
```

BenchmarkAll results for this branch:
```
goos: darwin
goarch: amd64
pkg: github.com/gorilla/schema
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkAll-16    	   23038	     52747 ns/op	   16906 B/op	     332 allocs/op
PASS
ok  	github.com/gorilla/schema	2.135s
```

Looking at a flamegraph of `parsePath` from `BenchmarkAll`, before and after:
<img width="1790" height="287" alt="image" src="https://github.com/user-attachments/assets/f2d29cb2-acc8-4f3d-a503-5bb57940fbe6" />
<img width="1790" height="287" alt="image" src="https://github.com/user-attachments/assets/7119ca37-1f68-43fa-b5e7-4dd9ca681438" />

In my personal workload the improvement is much greater. In my workload I re-use the Decoder, use far fewer structs, and have tens of input elements per Decode call. I have added the benchmark `BenchmarkSliceOfStruct` to represent this workload.

BenchmarkSliceOfStruct for main:
```
goos: darwin
goarch: amd64
pkg: github.com/gorilla/schema
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkSliceOfStruct-16    	   74332	     15562 ns/op	    5792 B/op	     176 allocs/op
PASS
ok  	github.com/gorilla/schema	1.932s
```

BenchmarkSliceOfStruct for this branch:
```
goos: darwin
goarch: amd64
pkg: github.com/gorilla/schema
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkSliceOfStruct-16    	   83041	     13373 ns/op	    4140 B/op	     124 allocs/op
PASS
ok  	github.com/gorilla/schema	1.807s
```
and of course, the before flamegraph:
<img width="1790" height="349" alt="image" src="https://github.com/user-attachments/assets/bcee26a9-0196-4f1f-964d-ac3d21937bcf" />
and after:
<img width="1790" height="349" alt="image" src="https://github.com/user-attachments/assets/b0cb117b-e135-41d3-a8ea-b8515cd6e6b8" />

as can be seen on this second flamegraph, there is definitely still an opportunity for more wins here because the largest is now spent making the preallocated slices. A larger refactor can be done to properly count the necessary sizes of the `paths` and `parts` slices, instead of my estimation using the number of `"."`.

This would require that we repeat the first operation of the loop, and count exactly how many paths and `sliceOfStruct` fields there are. And truth be told, as a first time contributor, I don't feel comfortable making a larger refactor like that 😆.  So, I settled for the choice to possibly over-allocate, and clip the slices to reduce the footprint outside of `parsePath`.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
  - `golangci-lint` is passing with a `go1.20` supporting version, although I could not get a version working for `gosec` and `govulncheck`. However, `make verify` with the latest versions of go and the linters fails with issues unrelated to this change. The lints are: https://staticcheck.dev/docs/checks/#QF1008 and gosec G115 (integer conversions)
- [x] `make test` is passing
